### PR TITLE
:bug: Fix controlnet_annotator_model_path cmd arg

### DIFF
--- a/extensions-builtin/forge_legacy_preprocessors/legacy_preprocessors/preprocessor.py
+++ b/extensions-builtin/forge_legacy_preprocessors/legacy_preprocessors/preprocessor.py
@@ -743,10 +743,10 @@ class InsightFaceModel:
         img = HWC3(img)
         faces = self.model.get(img)
         if not faces:
-            raise Exception(f"Insightface: No face found in image {i}.")
+            raise Exception(f"Insightface: No face found in image.")
         if len(faces) > 1:
             print("Insightface: More than one face is detected in the image. "
-                        f"Only the first one will be used {i}.")
+                        f"Only the first one will be used.")
         return torch.from_numpy(faces[0].normed_embedding).unsqueeze(0), False
 
     def run_model_instant_id(

--- a/modules_forge/shared.py
+++ b/modules_forge/shared.py
@@ -2,12 +2,14 @@ import os
 import ldm_patched.modules.utils
 
 from modules.paths import models_path
-
+from modules import shared
 
 controlnet_dir = os.path.join(models_path, 'ControlNet')
 os.makedirs(controlnet_dir, exist_ok=True)
 
-preprocessor_dir = os.path.join(models_path, 'ControlNetPreprocessor')
+preprocessor_dir = getattr(shared.cmd_opts, 'controlnet_annotator_models_path', None)
+if not preprocessor_dir:
+    preprocessor_dir = os.path.join(models_path, 'ControlNetPreprocessor')
 os.makedirs(preprocessor_dir, exist_ok=True)
 
 supported_preprocessors = {}


### PR DESCRIPTION
## Description

Fix `--controlnet_annotator_models_path` cmd arg.

Note: IPAdapter still download preprocessor models to a separate directory not affected by this commandline arg.

## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
