### PR TITLE
Auto open unit accordion

### DIFF
--- a/extensions-builtin/sd_forge_controlnet/javascript/active_units.js
+++ b/extensions-builtin/sd_forge_controlnet/javascript/active_units.js
@@ -289,8 +289,24 @@
 
         gradioApp().querySelectorAll('#controlnet').forEach(accordion => {
             if (cnetAllAccordions.has(accordion)) return;
-            accordion.querySelectorAll('.input-accordion')
-                .forEach(tab => new ControlNetUnitTab(tab, accordion));
+            const tabs = [...accordion.querySelectorAll('.input-accordion')]
+                .map(tab => new ControlNetUnitTab(tab, accordion));
+
+            // On open of main extension accordion, if no unit is enabled,
+            // open unit 0 for edit.
+            const labelWrap = accordion.querySelector('.label-wrap');
+            const observerAccordionOpen = new MutationObserver(function (mutations) {
+                for (const mutation of mutations) {
+                    if (mutation.target.classList.contains('open') &&
+                        tabs.every(tab => !tab.enabledCheckbox.checked &&
+                                          !tab.tab.querySelector('.label-wrap').classList.contains('open'))
+                    ) {
+                        tabs[0].tab.querySelector('.label-wrap').click();
+                    }
+                }
+            });
+            observerAccordionOpen.observe(labelWrap, { attributes: true, attributeFilter: ['class'] });
+
             cnetAllAccordions.add(accordion);
         });
     });

--- a/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
+++ b/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
@@ -78,7 +78,7 @@ class ControlNetForForgeOfficial(scripts.Script):
                 with gr.Row(elem_id=elem_id_tabname + "_accordions", elem_classes="accordions"):
                     for i in range(max_models):
                         with InputAccordion(
-                            value=i == 0,
+                            value=False,
                             label=f"ControlNet Unit {i}",
                             elem_classes=["cnet-unit-enabled-accordion"],  # Class on accordion
                         ):


### PR DESCRIPTION
## Description

Automatically open the first controlnet unit accordion when extension accordion opens.

## Screenshots/videos:
https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/20929282/a8ffa17b-68cb-4b98-a078-e3ec665d6ec3

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
