### PR TITLE
Filter ControlNet model based on active SD's version

### DIFF
--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/global_state.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/global_state.py
@@ -98,12 +98,18 @@ def get_filtered_preprocessor_names(tag):
     return list(get_filtered_preprocessors(tag).keys())
 
 
-def get_filtered_controlnet_names(tag):
+def get_filtered_controlnet_names(tag, filter_version: bool = True):
     filtered_preprocessors = get_filtered_preprocessors(tag)
     model_filename_filters = []
     for p in filtered_preprocessors.values():
         model_filename_filters += p.model_filename_filters
-    return [x for x in controlnet_names if any(f.lower() in x.lower() for f in model_filename_filters) or x == 'None']
+    return [
+        x for x in controlnet_names
+        if x == 'None' or (
+            any(f.lower() in x.lower() for f in model_filename_filters) and
+            get_sd_version().is_compatible_with(StableDiffusionVersion.detect_from_model_name(x))
+        )
+    ]
 
 
 def update_controlnet_filenames():


### PR DESCRIPTION
## Description
Filter ControlNet model based on current active SD checkpoint's version. Model name without version keywords are kept in the list.

## Screenshots/videos:
When selected SD15:
![1706933613783](https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/20929282/b2185ce1-245d-4a45-9709-1e1d3a237607)


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
