### PR TITLE
Add button to send generated image to svd tab

### DIFF
--- a/extensions-builtin/sd_forge_svd/scripts/forge_svd.py
+++ b/extensions-builtin/sd_forge_svd/scripts/forge_svd.py
@@ -3,6 +3,7 @@ import gradio as gr
 import os
 import pathlib
 
+import modules.infotext_utils as parameters_copypaste
 from modules import script_callbacks
 from modules.paths import models_path
 from modules.ui_common import ToolButton, refresh_symbol
@@ -106,6 +107,12 @@ def on_ui_tabs():
                                             visible=True, height=1024, columns=4)
 
         generate_button.click(predict, inputs=ctrls, outputs=[output_gallery, output_video])
+        PasteField = parameters_copypaste.PasteField
+        paste_fields = [
+            PasteField(width, "Size-1", api="width"),
+            PasteField(height, "Size-2", api="height"),
+        ]
+        parameters_copypaste.add_paste_fields("svd", init_img=input_image, fields=paste_fields)
     return [(svd_block, "SVD", "svd")]
 
 

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -82,6 +82,11 @@ function switch_to_extras() {
     return Array.from(arguments);
 }
 
+function switch_to_svd() {
+    gradioApp().querySelector('#tabs').querySelectorAll('button')[6].click();
+    return Array.from(arguments);
+}
+
 function get_tab_index(tabId) {
     let buttons = gradioApp().getElementById(tabId).querySelector('div').querySelectorAll('button');
     for (let i = 0; i < buttons.length; i++) {

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -206,7 +206,8 @@ Requested path was: {f}
                 buttons = {
                     'img2img': ToolButton('🖼️', elem_id=f'{tabname}_send_to_img2img', tooltip="Send image and generation parameters to img2img tab."),
                     'inpaint': ToolButton('🎨️', elem_id=f'{tabname}_send_to_inpaint', tooltip="Send image and generation parameters to img2img inpaint tab."),
-                    'extras': ToolButton('📐', elem_id=f'{tabname}_send_to_extras', tooltip="Send image and generation parameters to extras tab.")
+                    'extras': ToolButton('📐', elem_id=f'{tabname}_send_to_extras', tooltip="Send image and generation parameters to extras tab."),
+                    'svd': ToolButton('🎬', elem_id=f'{tabname}_send_to_svd', tooltip="Send image and generation parameters to SVD tab."),
                 }
 
                 if tabname == 'txt2img':


### PR DESCRIPTION
## Description

A movie button is added to send the generated image and its dimensions to SVD tab.

## Screenshots/videos:
![image](https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/20929282/5d5d5256-d71c-437d-bf2b-6483ffc44d06)


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
