### PR TITLE
Add back ControlNet model version filter

### DIFF
--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/global_state.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/global_state.py
@@ -98,7 +98,7 @@ def get_filtered_preprocessor_names(tag):
     return list(get_filtered_preprocessors(tag).keys())
 
 
-def get_filtered_controlnet_names(tag, filter_version: bool = True):
+def get_filtered_controlnet_names(tag):
     filtered_preprocessors = get_filtered_preprocessors(tag)
     model_filename_filters = []
     for p in filtered_preprocessors.values():
@@ -134,6 +134,8 @@ def update_controlnet_filenames():
 
 
 def get_sd_version() -> StableDiffusionVersion:
+    if not shared.sd_model:
+        return StableDiffusionVersion.UNKNOWN
     if shared.sd_model.is_sdxl:
         return StableDiffusionVersion.SDXL
     elif shared.sd_model.is_sd2:

--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/global_state.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/global_state.py
@@ -106,8 +106,8 @@ def get_filtered_controlnet_names(tag, filter_version: bool = True):
     return [
         x for x in controlnet_names
         if x == 'None' or (
-            any(f.lower() in x.lower() for f in model_filename_filters)  # and
-            # get_sd_version().is_compatible_with(StableDiffusionVersion.detect_from_model_name(x))
+            any(f.lower() in x.lower() for f in model_filename_filters) and
+            get_sd_version().is_compatible_with(StableDiffusionVersion.detect_from_model_name(x))
         )
     ]
 

--- a/modules/script_callbacks.py
+++ b/modules/script_callbacks.py
@@ -129,6 +129,9 @@ callback_map = dict(
     callbacks_list_optimizers=[],
     callbacks_list_unets=[],
 )
+event_subscriber_map = dict(
+    callbacks_setting_updated=[],
+)
 
 
 def clear_callbacks():
@@ -309,6 +312,23 @@ def list_unets_callback():
     return res
 
 
+def setting_updated_event_subscriber_chain(handler, component, setting_name: str):
+    """
+    Arguments:
+        - handler: The returned handler from calling an event subscriber.
+        - component: The component that is updated. The component should provide
+                     the value of setting after update.
+        - setting_name: The name of the setting.
+    """
+    for param in event_subscriber_map['callbacks_setting_updated']:
+        handler = handler.then(
+            fn=lambda *args: param["fn"](*args, setting_name),
+            inputs=param["inputs"] + [component],
+            outputs=param["outputs"],
+            show_progress=False,
+        )
+
+
 def add_callback(callbacks, fun):
     stack = [x for x in inspect.stack() if x.filename != __file__]
     filename = stack[0].filename if stack else 'unknown file'
@@ -483,3 +503,13 @@ def on_list_unets(callback):
     The function will be called with one argument, a list, and shall add objects of type modules.sd_unet.SdUnetOption to it."""
 
     add_callback(callback_map['callbacks_list_unets'], callback)
+
+
+def on_setting_updated_subscriber(subscriber_params):
+    """register a function to be called after settings update. `subscriber_params`
+    should contain necessary fields to register an gradio event handler. Necessary
+    fields are ["fn", "outputs", "inputs"].
+    Setting name and setting value after update will be append to inputs. So be
+    sure to handle these extra params when defining the callback function.
+    """
+    event_subscriber_map['callbacks_setting_updated'].append(subscriber_params)

--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -303,19 +303,29 @@ class UiSettings:
                 methods = [component.change]
 
             for method in methods:
-                method(
+                handler = method(
                     fn=lambda value, k=k: self.run_settings_single(value, key=k),
                     inputs=[component],
                     outputs=[component, self.text_settings],
                     show_progress=False,
                 )
+                script_callbacks.setting_updated_event_subscriber_chain(
+                    handler=handler,
+                    component=component,
+                    setting_name=k,
+                )
 
         button_set_checkpoint = gr.Button('Change checkpoint', elem_id='change_checkpoint', visible=False)
-        button_set_checkpoint.click(
+        handler = button_set_checkpoint.click(
             fn=lambda value, _: self.run_settings_single(value, key='sd_model_checkpoint'),
             _js="function(v){ var res = desiredCheckpointName; desiredCheckpointName = ''; return [res || v, null]; }",
             inputs=[self.component_dict['sd_model_checkpoint'], self.dummy_component],
             outputs=[self.component_dict['sd_model_checkpoint'], self.text_settings],
+        )
+        script_callbacks.setting_updated_event_subscriber_chain(
+            handler=handler,
+            component=self.component_dict['sd_model_checkpoint'],
+            setting_name="sd_model_checkpoint"
         )
 
         component_keys = [k for k in opts.data_labels.keys() if k in self.component_dict]


### PR DESCRIPTION
## Description

Closes https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/118.

This PR adds back version filter on ControlNet model selection.

Known issue:
On sd model change, the dropdown choice does not change accordingly. Now the workaround is to switch control type, and switch back to get the choices updated. This behaviour aligns with current behaviour in sd-webui-controlnet extension.

Directly observe change on `setting_sd_model_checkpoint` does not work perfectly as described in https://github.com/Mikubill/sd-webui-controlnet/issues/2524. We need to add `.then` callback on settings change in A1111 to solve this issue. See https://github.com/lllyasviel/stable-diffusion-webui-forge/blob/291ec743b603fdcd9c58e60dc5ed3d866c53bc4c/modules/ui_settings.py#L288-L320

## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
