### PR TITLE
Fix command line arguments format in webui-user.bat

### DIFF
--- a/webui-user.bat
+++ b/webui-user.bat
@@ -12,7 +12,7 @@ set COMMANDLINE_ARGS=
 @REM set COMMANDLINE_ARGS=%COMMANDLINE_ARGS% ^
 @REM  --ckpt-dir %A1111_HOME%/models/Stable-diffusion ^
 @REM  --hypernetwork-dir %A1111_HOME%/models/hypernetworks ^
-@REM  --embeddings-dir %A1111_HOME%/models/embeddings ^
+@REM  --embeddings-dir %A1111_HOME%/embeddings ^
 @REM  --lora-dir %A1111_HOME%/models/Lora
 
 call webui.bat

--- a/webui-user.bat
+++ b/webui-user.bat
@@ -9,10 +9,10 @@ set COMMANDLINE_ARGS=
 @REM set A1111_HOME=Your A1111 checkout dir
 @REM
 @REM set VENV_DIR=%A1111_HOME%/venv
-@REM set COMMANDLINE_ARGS=%COMMANDLINE_ARGS%^
-@REM  --ckpt-dir %A1111_HOME%/models/Stable-diffusion^
-@REM  --hypernetwork-dir %A1111_HOME%/models/hypernetworks^
-@REM  --embeddings-dir %A1111_HOME%/models/embeddings^
+@REM set COMMANDLINE_ARGS=%COMMANDLINE_ARGS% ^
+@REM  --ckpt-dir %A1111_HOME%/models/Stable-diffusion ^
+@REM  --hypernetwork-dir %A1111_HOME%/models/hypernetworks ^
+@REM  --embeddings-dir %A1111_HOME%/models/embeddings ^
 @REM  --lora-dir %A1111_HOME%/models/Lora
 
 call webui.bat


### PR DESCRIPTION
## Description
This PR addresses an issue in the `webui-user.bat` script where command line arguments were not properly formatted, leading to parsing errors when the script was executed. The correction involves adjusting the placement of spaces and carets (^) at the ends of lines that append arguments to the `COMMANDLINE_ARGS` variable.

And I corrected the path specified by `--embeddings-dir`.
https://github.com/lllyasviel/stable-diffusion-webui-forge/pull/135#issuecomment-1935055851

## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
