### PR TITLE
Fix CQ server arg

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -52,7 +52,7 @@ jobs:
           --do-not-download-clip
           --no-half
           --disable-opt-split-attention
-          --use-cpu all
+          --always-cpu
           --api-server-stop
           2>&1 | tee output.txt &
       - name: Run tests


### PR DESCRIPTION
## Description
`--use-cpu all` cmd arg is removed. Replace it with `--always-cpu`.

## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
