### PR TITLE
Fix import error

### DIFF
--- a/modules_forge/diffusers_patcher.py
+++ b/modules_forge/diffusers_patcher.py
@@ -3,7 +3,6 @@ import ldm_patched.modules.ops as ops
 
 from ldm_patched.modules.model_patcher import ModelPatcher
 from ldm_patched.modules import model_management
-from modules_forge.ops import use_patched_ops
 from transformers import modeling_utils
 
 
@@ -17,7 +16,7 @@ class DiffusersModelPatcher:
 
         self.dtype = dtype
 
-        with use_patched_ops(ops.manual_cast):
+        with ops.use_patched_ops(ops.manual_cast):
             with modeling_utils.no_init_weights():
                 self.pipeline = pipeline_class.from_pretrained(*args, **kwargs)
 


### PR DESCRIPTION
## Description

Fixes import path issue:
```
*** Error loading script: preprocessor_marigold.py
    Traceback (most recent call last):
      File "/home/runner/work/stable-diffusion-webui-forge/stable-diffusion-webui-forge/modules/scripts.py", line 541, in load_scripts
        script_module = script_loading.load_module(scriptfile.path)
      File "/home/runner/work/stable-diffusion-webui-forge/stable-diffusion-webui-forge/modules/script_loading.py", line 10, in load_module
        module_spec.loader.exec_module(module)
      File "<frozen importlib._bootstrap_external>", line 883, in exec_module
      File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
      File "/home/runner/work/stable-diffusion-webui-forge/stable-diffusion-webui-forge/extensions-builtin/forge_preprocessor_marigold/scripts/preprocessor_marigold.py", line 12, in <module>
        from modules_forge.diffusers_patcher import DiffusersModelPatcher
      File "/home/runner/work/stable-diffusion-webui-forge/stable-diffusion-webui-forge/modules_forge/diffusers_patcher.py", line 6, in <module>
        from modules_forge.ops import use_patched_ops
    ImportError: cannot import name 'use_patched_ops' from 'modules_forge.ops' (/home/runner/work/stable-diffusion-webui-forge/stable-diffusion-webui-forge/modules_forge/ops.py)
```

## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
