### PR TITLE
Accept image paths via ControlNet API

### DIFF
--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
@@ -5,6 +5,7 @@ import numpy as np
 from modules import shared
 from lib_controlnet.logging import logger
 from lib_controlnet.enums import InputMode, HiResFixOption
+from lib_controlnet.utils import image_dict_from_any
 from modules.api import api
 
 
@@ -208,12 +209,9 @@ class UiControlNetUnit:
         unit = UiControlNetUnit(
             **{k: v for k, v in d.items() if k in vars(UiControlNetUnit)}
         )
-        if isinstance(unit.image, str):
-            img = np.array(api.decode_base64_to_image(unit.image)).astype('uint8')
-            unit.image = {
-                "image": img,
-                "mask": np.zeros_like(img),
-            }
+        
+        unit.image = image_dict_from_any(unit.image)
+
         if isinstance(unit.mask_image, str):
             unit.mask_image = np.array(api.decode_base64_to_image(unit.mask_image)).astype('uint8')
         return unit


### PR DESCRIPTION
## Description

when using ControlNet via API, it is necessary to convert images to base64. 

This PR modifies it to accept image paths when sending images via the API.

## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
