### PR TITLE
Fix ControlNet outpaint

### DIFF
--- a/extensions-builtin/sd_forge_controlnet/tests/web_api/generation_test.py
+++ b/extensions-builtin/sd_forge_controlnet/tests/web_api/generation_test.py
@@ -150,8 +150,6 @@ def test_img2img_inpaint():
     ).exec()
 
 
-# Currently failing.
-# TODO Fix lama outpaint.
 @disable_in_cq
 def test_lama_outpaint():
     assert APITestTemplate(
@@ -168,4 +166,20 @@ def test_lama_outpaint():
             "module": "inpaint_only+lama",
             "resize_mode": "Resize and Fill",  # OUTER_FIT
         },
-    ).exec()
+    ).exec(result_only=False)
+    assert APITestTemplate(
+        "img2img_lama_outpaint",
+        "img2img",
+        payload_overrides={
+            "init_images": [girl_img],
+            "width": 768,
+            "height": 768,
+            "resize_mode": 2,  # OUTER_FIT
+            "denoising_strength": 0.1,
+        },
+        # Outpaint should not need a mask.
+        unit_overrides={
+            "model": get_model("v11p_sd15_inpaint"),
+            "module": "inpaint_only+lama",
+        },
+    ).exec(result_only=False)

--- a/extensions-builtin/sd_forge_controlnet/tests/web_api/generation_test.py
+++ b/extensions-builtin/sd_forge_controlnet/tests/web_api/generation_test.py
@@ -158,6 +158,8 @@ def test_lama_outpaint():
         payload_overrides={
             "width": 768,
             "height": 768,
+            "steps": 20,
+            "sampler": "DPM++ 2M Karras",
         },
         # Outpaint should not need a mask.
         unit_overrides={
@@ -167,19 +169,25 @@ def test_lama_outpaint():
             "resize_mode": "Resize and Fill",  # OUTER_FIT
         },
     ).exec(result_only=False)
+
+
+@disable_in_cq
+def test_lama_outpaint_with_mask():
+    """The union of outpaint area and mask area should be used as new mask."""
     assert APITestTemplate(
-        "img2img_lama_outpaint",
-        "img2img",
+        "txt2img_lama_outpaint_with_mask",
+        "txt2img",
         payload_overrides={
-            "init_images": [girl_img],
             "width": 768,
             "height": 768,
-            "resize_mode": 2,  # OUTER_FIT
-            "denoising_strength": 0.1,
+            "steps": 20,
+            "sampler": "DPM++ 2M Karras",
         },
-        # Outpaint should not need a mask.
         unit_overrides={
+            "image": girl_img,
+            "mask_image": mask_img,
             "model": get_model("v11p_sd15_inpaint"),
             "module": "inpaint_only+lama",
+            "resize_mode": "Resize and Fill",  # OUTER_FIT
         },
     ).exec(result_only=False)


### PR DESCRIPTION
## Description
Closes https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/200. Try fix ControlNet outpaint.

Reference: https://github.com/Mikubill/sd-webui-controlnet/discussions/1597
Lama outpaint is only supported in txt2img.

## Screenshots/videos:
![1707797027597](https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/20929282/e98d1829-b027-401c-82a3-17830599ec0f)

Txt2img outpaint outputs:
![image](https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/20929282/cdfe74ac-aaa0-4437-a535-8d144b768259)
![txt2img_lama_outpaint_1](https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/20929282/9cdfbbba-75b7-4e10-8faf-541731270c78)
![txt2img_lama_outpaint_2](https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/20929282/9d51e5a5-6927-484b-8207-9971f5a5c81b)

## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
