### PR TITLE
Fix embeddings path (--forge-ref-a1111-home)

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -515,7 +515,7 @@ def configure_forge_reference_checkout(a1111_home: Path):
         ModelRef(arg_name="--ckpt-dir", relative_path="models/Stable-diffusion"),
         ModelRef(arg_name="--vae-dir", relative_path="models/VAE"),
         ModelRef(arg_name="--hypernetwork-dir", relative_path="models/hypernetworks"),
-        ModelRef(arg_name="--embeddings-dir", relative_path="models/embeddings"),
+        ModelRef(arg_name="--embeddings-dir", relative_path="embeddings"),
         ModelRef(arg_name="--lora-dir", relative_path="models/lora"),
         # Ref A1111 need to have sd-webui-controlnet installed.
         ModelRef(arg_name="--controlnet-dir", relative_path="models/ControlNet"),


### PR DESCRIPTION
## Description
The following PR is really cool. It makes the process of setting up A1111 much clearer.
https://github.com/lllyasviel/stable-diffusion-webui-forge/pull/203

One note about this fix the way to specify the path for the `--embeddings-dir` was incorrect, so I've corrected that.

I would appreciate it if you could check it out.

## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
