### PR TITLE
make the output path consistent with a1111

### DIFF
--- a/modules/paths_internal.py
+++ b/modules/paths_internal.py
@@ -32,6 +32,6 @@ models_path = os.path.join(data_path, "models")
 extensions_dir = os.path.join(data_path, "extensions")
 extensions_builtin_dir = os.path.join(script_path, "extensions-builtin")
 config_states_dir = os.path.join(script_path, "config_states")
-default_output_dir = os.path.join(data_path, "output")
+default_output_dir = os.path.join(data_path, "outputs")
 
 roboto_ttf_file = os.path.join(modules_path, 'Roboto-Regular.ttf')


### PR DESCRIPTION
## Description

* a simple description of what you're trying to accomplish

I noticed that the output folder as changed from `outputs` to `output` in this commit https://github.com/lllyasviel/stable-diffusion-webui-forge/commit/af2951ed53da6d357aea9232538f9ea7e1cdc648 while extracting out the `default_output_dir` attribute.

Not sure if this was intentional or a mistake, but unless there's a good reason to do this, I think the folder name should be the same.

For example, some extensions or 3rd party apps may want to access files in the output folder but since the folder names are different for a1111 and forge, a separate handler needs to be written, which introduces unnecessary complexity, when the main philosophy of Forge is:

> Forge promise that we will only do our jobs. Forge will never add unnecessary opinioned changes to the user interface. You are still using 100% Automatic1111 WebUI.

* a summary of changes in code

Literally just a single character change from `output` back to `outputs` (which it used to be, and is consistent with a1111)

* which issues it fixes, if any

## Screenshots/videos:


## Checklist:

- [O] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [O] I have performed a self-review of my own code
- [O] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [O] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
