### PR TITLE
Fix LoRA infotext

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -27,7 +27,10 @@ def assign_network_names_to_compvis_modules(sd_model):
 
 
 def load_network(name, network_on_disk):
-    pass
+    net = network.Network(name, network_on_disk)
+    net.mtime = os.path.getmtime(network_on_disk.filename)
+
+    return net
 
 
 def purge_networks_from_memory():
@@ -41,10 +44,22 @@ def load_networks(names, te_multipliers=None, unet_multipliers=None, dyn_dims=No
     if current_sd is None:
         return
 
+    loaded_networks.clear()
+
     networks_on_disk = [available_networks.get(name, None) if name.lower() in forbidden_network_aliases else available_network_aliases.get(name, None) for name in names]
     if any(x is None for x in networks_on_disk):
         list_available_networks()
         networks_on_disk = [available_networks.get(name, None) if name.lower() in forbidden_network_aliases else available_network_aliases.get(name, None) for name in names]
+
+    for i, (network_on_disk, name) in enumerate(zip(networks_on_disk, names)):
+        try:
+            net = load_network(name, network_on_disk)
+        except Exception as e:
+            errors.display(e, f"loading network {network_on_disk.filename}")
+            continue
+        net.mentioned_name = name
+        network_on_disk.read_hash()
+        loaded_networks.append(net)
 
     compiled_lora_targets = []
     for a, b, c in zip(networks_on_disk, unet_multipliers, te_multipliers):


### PR DESCRIPTION
## Description

Closes https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/372

Fixes LoRA information, specifically hashes, being missing from the infotext.

Code is adapted from these relevant locations upstream:
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/18819723c1d727a5a96224011607963d44a04d36/extensions-builtin/Lora/networks.py#L146-L148
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/18819723c1d727a5a96224011607963d44a04d36/extensions-builtin/Lora/networks.py#L271

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
