### PR TITLE
controlnet extension - few compat fixes

### DIFF
--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Union, Dict, TypedDict
+from typing import List, Optional, Union, Dict, TypedDict, Any
 import numpy as np
 from modules import shared
 from lib_controlnet.logging import logger
@@ -297,3 +297,16 @@ def get_max_models_num():
 
     max_models_num = shared.opts.data.get("control_net_unit_count", 3)
     return max_models_num
+
+
+
+def to_processing_unit(unit: Union[Dict[str, Any], ControlNetUnit]) -> ControlNetUnit:
+    """
+    Convert different types to processing unit.
+    Backward Compatible
+    """
+
+    if isinstance(unit, dict):
+        unit = ControlNetUnit.from_dict(unit)
+
+    return unit

--- a/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
+++ b/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
@@ -104,6 +104,7 @@ class ControlNetForForgeOfficial(scripts.Script):
             ControlNetUnit.from_dict(unit) if isinstance(unit, dict) else unit
             for unit in units
         ]
+        units = [unit for unit in units if unit is not None]
         assert all(isinstance(unit, ControlNetUnit) for unit in units)
         enabled_units = [x for x in units if x.enabled]
         return enabled_units


### PR DESCRIPTION
In support forge in my extension I've faced external_code no longer has `to_processing_unit`. And also it produces errors if few units are None

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
