### PR TITLE
Fix alphas cumprod

### DIFF
--- a/ldm_patched/modules/model_sampling.py
+++ b/ldm_patched/modules/model_sampling.py
@@ -76,7 +76,13 @@ class ModelSamplingDiscrete(torch.nn.Module):
     def timestep(self, sigma):
         log_sigma = sigma.log()
         dists = log_sigma.to(self.log_sigmas.device) - self.log_sigmas[:, None]
-        return dists.abs().argmin(dim=0).view(sigma.shape).to(sigma.device)
+        low_idx = dists.ge(0).cumsum(dim=0).argmax(dim=0).clamp(max=self.log_sigmas.shape[0] - 2)
+        high_idx = low_idx + 1
+        low, high = self.log_sigmas[low_idx], self.log_sigmas[high_idx]
+        w = (low - log_sigma) / (low - high)
+        w = w.clamp(0, 1)
+        t = (1 - w) * low_idx + w * high_idx
+        return t.view(sigma.shape)
 
     def sigma(self, timestep):
         t = torch.clamp(timestep.float().to(self.log_sigmas.device), min=0, max=(len(self.sigmas) - 1))

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -917,11 +917,13 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                 alphas_cumprod_backup = p.sd_model.alphas_cumprod
                 for modifier in alphas_cumprod_modifiers:
                     p.sd_model.alphas_cumprod = modifier(p.sd_model.alphas_cumprod)
+                p.sd_model.forge_objects.unet.model.model_sampling.set_sigmas(((1 - p.sd_model.alphas_cumprod) / p.sd_model.alphas_cumprod) ** 0.5)
 
             samples_ddim = p.sample(conditioning=p.c, unconditional_conditioning=p.uc, seeds=p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, prompts=p.prompts)
 
             if alphas_cumprod_backup is not None:
                 p.sd_model.alphas_cumprod = alphas_cumprod_backup
+                p.sd_model.forge_objects.unet.model.model_sampling.set_sigmas(((1 - p.sd_model.alphas_cumprod) / p.sd_model.alphas_cumprod) ** 0.5)
 
             if p.scripts is not None:
                 ps = scripts.PostSampleArgs(samples_ddim)


### PR DESCRIPTION
Without this PR, I cannot reproduce any result from auto upstream.
 
The reason is that ComfyUI init alphas cumprod at model loading time instead of sample time (auto does this) so we need another step.

Another change is that ComfyUI always does "[quantize](https://github.com/crowsonkb/k-diffusion/blob/master/k_diffusion/external.py#L70)" when it convert sigma to t, but A1111 never does "quantize" from my observation.

Comparison:
| A1111 v1.8.0 | Forge before this change | Forge after this change |
| --- | --- | --- |
| ![00007-564673848](https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/63914308/9a0181f6-78b6-4683-9b9a-b7362be3b5c3) | ![00000-564673848](https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/63914308/eedeb166-4e00-4b5f-9ff6-615953096aff) | ![00001-564673848](https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/63914308/7ac8bb8f-877e-44a6-a9f0-1ae4e3b89b50) |