### PR TITLE
Temp fix to make soft inpainting work

### DIFF
--- a/modules/sd_samplers_cfg_denoiser.py
+++ b/modules/sd_samplers_cfg_denoiser.py
@@ -172,9 +172,23 @@ class CFGDenoiser(torch.nn.Module):
         cond_composition, cond = prompt_parser.reconstruct_multicond_batch(cond, self.step)
         uncond = prompt_parser.reconstruct_cond_batch(uncond, self.step)
 
-        if self.mask is not None:
+        # If we use masks, blending between the denoised and original latent images occurs here.
+        def apply_blend(current_latent, noisy_initial_latent=None):
+            if noisy_initial_latent is None:
+                noisy_initial_latent = self.init_latent
+            blended_latent = current_latent * self.nmask + noisy_initial_latent * self.mask
+
+            if self.p.scripts is not None:
+                from modules import scripts
+                mba = scripts.MaskBlendArgs(current_latent, self.nmask, self.init_latent, self.mask, blended_latent, denoiser=self, sigma=sigma)
+                self.p.scripts.on_mask_blend(self.p, mba)
+                blended_latent = mba.blended_latent
+
+            return blended_latent
+
+        if self.mask_before_denoising and self.mask is not None:
             noisy_initial_latent = self.init_latent + sigma[:, None, None, None] * torch.randn_like(self.init_latent).to(self.init_latent)
-            x = x * self.nmask + noisy_initial_latent * self.mask
+            x = apply_blend(x, noisy_initial_latent)
 
         denoiser_params = CFGDenoiserParams(x, image_cond, sigma, state.sampling_step, state.sampling_steps, cond, uncond, self)
         cfg_denoiser_callback(denoiser_params)
@@ -182,8 +196,8 @@ class CFGDenoiser(torch.nn.Module):
         denoised = forge_sampler.forge_sample(self, denoiser_params=denoiser_params,
                                               cond_scale=cond_scale, cond_composition=cond_composition)
 
-        if self.mask is not None:
-            denoised = denoised * self.nmask + self.init_latent * self.mask
+        if not self.mask_before_denoising and self.mask is not None:
+            denoised = apply_blend(denoised)
 
         preview = self.sampler.last_latent = denoised
         sd_samplers_common.store_latent(preview)


### PR DESCRIPTION
Addresses https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/490 -- this PR is more or less to bring this to attention.

This isn't the correct fix as this undoes a couple changes made by @lllyasviel, but I'm unsure what the correct solution is here. `mask_before_denoising` is only ever set to `True` [here](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/bef51aed032c0aaa5cfd80445bc4cf0d85b408b5/modules/sd_samplers_timesteps.py#L53), but that code is not present in Forge, meaning it's always `False`.

Relevant `apply_blend` code adapted from here: https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/eee46a5094f748ebe9fe4978b0d440a8ebbab4a6/modules/sd_samplers_cfg_denoiser.py#L168-L178