### PR TITLE
Fix lora path (--forge-ref-a1111-home)

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -516,7 +516,7 @@ def configure_forge_reference_checkout(a1111_home: Path):
         ModelRef(arg_name="--vae-dir", relative_path="models/VAE"),
         ModelRef(arg_name="--hypernetwork-dir", relative_path="models/hypernetworks"),
         ModelRef(arg_name="--embeddings-dir", relative_path="embeddings"),
-        ModelRef(arg_name="--lora-dir", relative_path="models/lora"),
+        ModelRef(arg_name="--lora-dir", relative_path="models/Lora"),
         # Ref A1111 need to have sd-webui-controlnet installed.
         ModelRef(arg_name="--controlnet-dir", relative_path="models/ControlNet"),
         ModelRef(arg_name="--controlnet-preprocessor-models-dir", relative_path="extensions/sd-webui-controlnet/annotator/downloads"),


### PR DESCRIPTION
## Description

* When i set --forge-ref-a1111-home, the forge cann't find the lora of origin sd-webui
* Because forge used `models/lora` as relative_path of lora, ranther than `models/Lora`
* So this PR is just for fixing the lora path

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
