### PR TITLE
Fix for controlnet(integrated)'s api

### DIFF
--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
@@ -261,8 +261,8 @@ class ControlNetUnit:
                 "image": img,
                 "mask": np.zeros_like(img),
             }
-        if isinstance(unit.mask_image, str):
-            mask = np.array(api.decode_base64_to_image(unit.mask_image)).astype('uint8')
+        if isinstance(unit.mask_image['image'], str):
+            mask = np.array(api.decode_base64_to_image(unit.mask_image['image'])).astype('uint8')
             if unit.image is not None:
                 # Attach mask on image if ControlNet has input image.
                 assert isinstance(unit.image, dict)

--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
@@ -255,8 +255,8 @@ class ControlNetUnit:
         unit = ControlNetUnit(
             **{k: v for k, v in d.items() if k in vars(ControlNetUnit)}
         )
-        if isinstance(unit.image, str):
-            img = np.array(api.decode_base64_to_image(unit.image)).astype('uint8')
+        if isinstance(unit.image['image'], str):
+            img = np.array(api.decode_base64_to_image(unit.image['image'])).astype('uint8')
             unit.image = {
                 "image": img,
                 "mask": np.zeros_like(img),

--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
@@ -255,13 +255,13 @@ class ControlNetUnit:
         unit = ControlNetUnit(
             **{k: v for k, v in d.items() if k in vars(ControlNetUnit)}
         )
-        if isinstance(unit.image['image'], str):
+        if unit.image is not None and isinstance(unit.image['image'], str):
             img = np.array(api.decode_base64_to_image(unit.image['image'])).astype('uint8')
             unit.image = {
                 "image": img,
                 "mask": np.zeros_like(img),
             }
-        if isinstance(unit.mask_image['image'], str):
+        if unit.mask_image is not None and isinstance(unit.mask_image['image'], str):
             mask = np.array(api.decode_base64_to_image(unit.mask_image['image'])).astype('uint8')
             if unit.image is not None:
                 # Attach mask on image if ControlNet has input image.


### PR DESCRIPTION
## Description
Currently, sending an api request to controlnet integrated may result in issues. This is due to the base64 encoded images being accidentally left in base64 format. A check fails [here](https://github.com/papuSpartan/stable-diffusion-webui-forge/blob/01c24e44a624a1b85e125e5e35b3b572a3c78755/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py#L258) because `unit.image` (and later `unit.mask_image` also) are always of type `dict`. The original comparison looks to be checking if contents are type `str` to infer if they are encoded. In practice, this fails without checking the `image` key for each which should actually contain the b64 image string.

May resolve: #439, #259, papuSpartan/stable-diffusion-webui-distributed#25


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
