### PR TITLE
Fix spelling errors "corp_image..."

### DIFF
--- a/extensions-builtin/forge_preprocessor_reference/scripts/forge_reference.py
+++ b/extensions-builtin/forge_preprocessor_reference/scripts/forge_reference.py
@@ -40,7 +40,7 @@ class PreprocessorReference(Preprocessor):
         self.slider_resolution = PreprocessorParameter(visible=False)
         self.slider_1 = PreprocessorParameter(label='Style Fidelity', value=0.5, minimum=0.0, maximum=1.0, step=0.01, visible=True)
         self.show_control_mode = False
-        self.corp_image_with_a1111_mask_when_in_img2img_inpaint_tab = False
+        self.crop_image_with_a1111_mask_when_in_img2img_inpaint_tab = False
         self.do_not_need_model = True
 
         self.is_recording_style = False

--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/api.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/api.py
@@ -11,6 +11,8 @@ from .global_state import (
     get_all_preprocessor_names,
     get_all_controlnet_names,
     get_preprocessor,
+    get_all_preprocessor_tags,
+    select_control_type,
 )
 from .utils import judge_image_type
 from .logging import logger
@@ -51,6 +53,30 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
             "module_list": module_list,
             # TODO: Add back module detail.
             # "module_detail": external_code.get_modules_detail(alias_names),
+        }
+
+    @app.get("/controlnet/control_types")
+    async def control_types():
+        def format_control_type(
+            filtered_preprocessor_list,
+            filtered_model_list,
+            default_option,
+            default_model,
+        ):
+            control_dict = {
+                    "module_list": filtered_preprocessor_list,
+                    "model_list": filtered_model_list,
+                    "default_option": default_option,
+                    "default_model": default_model,
+                }
+
+            return control_dict
+
+        return {
+            "control_types": {
+                control_type: format_control_type(*select_control_type(control_type))
+                for control_type in get_all_preprocessor_tags()
+            }
         }
 
     @app.post("/controlnet/detect")

--- a/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
+++ b/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
@@ -123,7 +123,7 @@ class ControlNetForForgeOfficial(scripts.Script):
                 a1111_mask_image is not None
         )
         if (
-                preprocessor.corp_image_with_a1111_mask_when_in_img2img_inpaint_tab
+                preprocessor.crop_image_with_a1111_mask_when_in_img2img_inpaint_tab
                 and is_only_masked_inpaint
         ):
             logger.info("Crop input image based on A1111 mask.")

--- a/extensions-builtin/sd_forge_ipadapter/scripts/forge_ipadapter.py
+++ b/extensions-builtin/sd_forge_ipadapter/scripts/forge_ipadapter.py
@@ -61,7 +61,7 @@ class PreprocessorInsightFaceForInstantID(Preprocessor):
         self.model_filename_filters = ['Instant-ID', 'Instant_ID']
         self.sorting_priority = 20
         self.slider_resolution = PreprocessorParameter(visible=False)
-        self.corp_image_with_a1111_mask_when_in_img2img_inpaint_tab = False
+        self.crop_image_with_a1111_mask_when_in_img2img_inpaint_tab = False
         self.show_control_mode = False
         self.sorting_priority = 10
         self.cached_insightface = None

--- a/extensions-builtin/sd_forge_photomaker/scripts/forge_photomaker.py
+++ b/extensions-builtin/sd_forge_photomaker/scripts/forge_photomaker.py
@@ -16,7 +16,7 @@ class PreprocessorClipvisionForPhotomaker(Preprocessor):
         self.model_filename_filters = ['PhotoMaker', 'Photo_Maker', 'Photo-Maker']
         self.sorting_priority = 20
         self.slider_resolution = PreprocessorParameter(visible=False)
-        self.corp_image_with_a1111_mask_when_in_img2img_inpaint_tab = False
+        self.crop_image_with_a1111_mask_when_in_img2img_inpaint_tab = False
         self.show_control_mode = False
 
 

--- a/modules_forge/supported_preprocessor.py
+++ b/modules_forge/supported_preprocessor.py
@@ -30,7 +30,7 @@ class Preprocessor:
         self.show_control_mode = True
         self.do_not_need_model = False
         self.sorting_priority = 0  # higher goes to top in the list
-        self.corp_image_with_a1111_mask_when_in_img2img_inpaint_tab = True
+        self.crop_image_with_a1111_mask_when_in_img2img_inpaint_tab = True
         self.fill_mask_with_one_when_resize_and_fill = False
         self.use_soft_projection_in_hr_fix = False
         self.expand_mask_when_resize_and_fill = False
@@ -109,7 +109,7 @@ class PreprocessorClipVision(Preprocessor):
         self.url = url
         self.filename = filename
         self.slider_resolution = PreprocessorParameter(visible=False)
-        self.corp_image_with_a1111_mask_when_in_img2img_inpaint_tab = False
+        self.crop_image_with_a1111_mask_when_in_img2img_inpaint_tab = False
         self.show_control_mode = False
         self.sorting_priority = 1
         self.clipvision = None


### PR DESCRIPTION
## Description

Corrects the spelling of 6 instances of 'corp_image_with_a1111_mask_when_in_img2img_inpaint_tab'

corp ----------> crop

## Screenshots/videos:

<img width="736" alt="Screenshot 2024-04-02 194254" src="https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/1613484/450aaf94-1ffa-4a9b-9e92-761fd528bf86">


## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
