### PR TITLE
Use uncached file stats when updating previews; use selected image from gallery

### DIFF
--- a/extensions-builtin/Lora/ui_extra_networks_lora.py
+++ b/extensions-builtin/Lora/ui_extra_networks_lora.py
@@ -15,7 +15,7 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
     def refresh(self):
         networks.list_available_networks()
 
-    def create_item(self, name, index=None, enable_filter=True):
+    def create_item(self, name, index=None, enable_filter=True, force=False):
         lora_on_disk = networks.available_networks.get(name)
         if lora_on_disk is None:
             return
@@ -31,7 +31,7 @@ class ExtraNetworksPageLora(ui_extra_networks.ExtraNetworksPage):
             "name": name,
             "filename": lora_on_disk.filename,
             "shorthash": lora_on_disk.shorthash,
-            "preview": self.find_preview(path),
+            "preview": self.find_preview(path, force),
             "description": self.find_description(path),
             "search_terms": search_terms,
             "local_preview": f"{path}.{shared.opts.samples_format}",

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -7,23 +7,23 @@ function set_theme(theme) {
     }
 }
 
-function all_gallery_buttons() {
+function all_gallery_buttons(onlyVisible = true) {
     var allGalleryButtons = gradioApp().querySelectorAll('[style="display: block;"].tabitem div[id$=_gallery].gradio-gallery .thumbnails > .thumbnail-item.thumbnail-small');
     var visibleGalleryButtons = [];
     allGalleryButtons.forEach(function(elem) {
-        if (elem.parentElement.offsetParent) {
+        if (elem.parentElement.offsetParent || !onlyVisible) {
             visibleGalleryButtons.push(elem);
         }
     });
     return visibleGalleryButtons;
 }
 
-function selected_gallery_button() {
-    return all_gallery_buttons().find(elem => elem.classList.contains('selected')) ?? null;
+function selected_gallery_button(onlyVisible = true) {
+    return all_gallery_buttons(onlyVisible).find(elem => elem.classList.contains('selected')) ?? null;
 }
 
-function selected_gallery_index() {
-    return all_gallery_buttons().findIndex(elem => elem.classList.contains('selected'));
+function selected_gallery_index(onlyVisible = true) {
+    return all_gallery_buttons(onlyVisible).findIndex(elem => elem.classList.contains('selected'));
 }
 
 function extract_image_from_gallery(gallery) {

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -128,15 +128,13 @@ def get_single_card(page: str = "", tabname: str = "", name: str = ""):
     page = next(iter([x for x in extra_pages if x.name == page]), None)
 
     try:
-        item = page.create_item(name, enable_filter=False)
+        item = page.create_item(name, enable_filter=False, force=True)
         page.items[name] = item
     except Exception as e:
         errors.display(e, "creating item for extra network")
         item = page.items.get(name)
-
     page.read_user_metadata(item, use_cache=False)
     item_html = page.create_item_html(tabname, item, shared.html("extra-networks-card.html"))
-
     return JSONResponse({"html": item_html})
 
 
@@ -183,9 +181,9 @@ class ExtraNetworksPage:
 
         item["user_metadata"] = metadata
 
-    def link_preview(self, filename):
+    def link_preview(self, filename, force=False):
         quoted_filename = urllib.parse.quote(filename.replace('\\', '/'))
-        mtime, _ = self.lister.mctime(filename)
+        mtime, _ = self.lister.mctime(filename, force)
         return f"./sd_extra_networks/thumb?filename={quoted_filename}&mtime={mtime}"
 
     def search_terms_from_path(self, filename, possible_directories=None):
@@ -571,7 +569,7 @@ class ExtraNetworksPage:
             "path": str(pth).lower(),
         }
 
-    def find_preview(self, path):
+    def find_preview(self, path, force=False):
         """
         Find a preview PNG for a given path (without extension) and call link_preview on it.
         """
@@ -580,7 +578,7 @@ class ExtraNetworksPage:
 
         for file in potential_files:
             if self.lister.exists(file):
-                return self.link_preview(file)
+                return self.link_preview(file, force)
 
         return None
 

--- a/modules/ui_extra_networks_user_metadata.py
+++ b/modules/ui_extra_networks_user_metadata.py
@@ -68,14 +68,14 @@ class UserMetadataEditor:
 
         self.button_cancel.click(fn=None, _js="closePopup")
 
-    def get_card_html(self, name):
+    def get_card_html(self, name, force=False):
         item = self.page.items.get(name, {})
 
         preview_url = item.get("preview", None)
 
-        if not preview_url:
+        if not preview_url or force:
             filename, _ = os.path.splitext(item["filename"])
-            preview_url = self.page.find_preview(filename)
+            preview_url = self.page.find_preview(filename, force)
             item["preview"] = preview_url
 
         if preview_url:
@@ -186,12 +186,12 @@ class UserMetadataEditor:
 
         images.save_image_with_geninfo(image, geninfo, item["local_preview"])
 
-        return self.get_card_html(name), ''
+        return self.get_card_html(name, True), ''
 
     def setup_ui(self, gallery):
         self.button_replace_preview.click(
             fn=self.save_preview,
-            _js="function(x, y, z){return [selected_gallery_index(), y, z]}",
+            _js="function(x, y, z){ return [selected_gallery_index(false), y, z];}",
             inputs=[self.edit_name_input, gallery, self.edit_name_input],
             outputs=[self.html_preview, self.html_status]
         ).then(


### PR DESCRIPTION
## Description

When a preview is updated in the LORA page it won't refresh in the browser since the generated HTML contains the cached timestamp.

These changes allow forcing fetching the preview timestamps from the OS when a new preview is loaded.

Also: it will correctly use the selected image from the generation tab. Before the fix it would always fall back to the first one, since it would only try and fetch the visible images and when in the User Metadata Editor none are actually visible.
## Screenshots/videos:


## Checklist:

- [ X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ X] I have performed a self-review of my own code
- [ X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
