### PR TITLE
Add avif support 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,5 @@ torch
 torchdiffeq
 torchsde
 transformers==4.30.2
+
+pillow-avif-plugin==1.4.3

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -30,3 +30,4 @@ transformers==4.30.2
 httpx==0.24.1
 basicsr==1.4.2
 diffusers==0.25.0
+pillow-avif-plugin==1.4.3


### PR DESCRIPTION
## Description
Avif is more efficient for storage compared to .jpeg or .webp


Adds .avif support for genrated images and for parsing exif data 
Exif data is stored in `UserComment` similar to .jpeg, .webp

I have also removed the second "user comment" field from image info for formats other than png, it looks same as png now.


It adds [`pillow-avif-plugin`](https://github.com/fdintino/pillow-avif-plugin/) to dependencies [because avif isn't supported by pillow yet](https://github.com/python-pillow/Pillow/pull/5201)


## Checklist:

- [*] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [*] I have performed a self-review of my own code
- [*] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [*] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
