### PR TITLE
Add cos xl

### DIFF
--- a/ldm_patched/modules/model_sampling.py
+++ b/ldm_patched/modules/model_sampling.py
@@ -107,9 +107,11 @@ class ModelSamplingContinuousEDM(torch.nn.Module):
 
         sigma_min = sampling_settings.get("sigma_min", 0.002)
         sigma_max = sampling_settings.get("sigma_max", 120.0)
-        self.set_sigma_range(sigma_min, sigma_max)
+        sigma_data = sampling_settings.get("sigma_data", 1.0)
+        self.set_sigma_range(sigma_min, sigma_max, sigma_data)
 
-    def set_sigma_range(self, sigma_min, sigma_max):
+    def set_sigma_range(self, sigma_min, sigma_max, sigma_data):
+        self.sigma_data = sigma_data
         sigmas = torch.linspace(math.log(sigma_min), math.log(sigma_max), 1000).exp()
 
         self.register_buffer('sigmas', sigmas) #for compatibility with some schedulers

--- a/ldm_patched/modules/supported_models.py
+++ b/ldm_patched/modules/supported_models.py
@@ -170,9 +170,9 @@ class SDXL(supported_models_base.BASE):
         if "v_pred" in state_dict:
             return model_base.ModelType.V_PREDICTION
         elif "edm_vpred.sigma_max" in state_dict:
-            self.sampling_settings["sigma_max"] = float(state_dict["edm_vpred.sigma_max"].item())
+            self.sampling_settings["sigma_max"] = round(float(state_dict["edm_vpred.sigma_max"].item()),3)
             if "edm_vpred.sigma_min" in state_dict:
-                self.sampling_settings["sigma_min"] = float(state_dict["edm_vpred.sigma_min"].item())
+                self.sampling_settings["sigma_min"] = round(float(state_dict["edm_vpred.sigma_min"].item()),3)
             return model_base.ModelType.V_PREDICTION_EDM
         else:
             return model_base.ModelType.EPS

--- a/ldm_patched/modules/supported_models.py
+++ b/ldm_patched/modules/supported_models.py
@@ -170,6 +170,9 @@ class SDXL(supported_models_base.BASE):
         if "v_pred" in state_dict:
             return model_base.ModelType.V_PREDICTION
         elif "edm_vpred.sigma_max" in state_dict:
+            self.sampling_settings["sigma_max"] = float(state_dict["edm_vpred.sigma_max"].item())
+            if "edm_vpred.sigma_min" in state_dict:
+                self.sampling_settings["sigma_min"] = float(state_dict["edm_vpred.sigma_min"].item())
             return model_base.ModelType.V_PREDICTION_EDM
         else:
             return model_base.ModelType.EPS

--- a/ldm_patched/modules/supported_models.py
+++ b/ldm_patched/modules/supported_models.py
@@ -169,6 +169,8 @@ class SDXL(supported_models_base.BASE):
     def model_type(self, state_dict, prefix=""):
         if "v_pred" in state_dict:
             return model_base.ModelType.V_PREDICTION
+        elif "edm_vpred.sigma_max" in state_dict:
+            return model_base.ModelType.V_PREDICTION_EDM
         else:
             return model_base.ModelType.EPS
 


### PR DESCRIPTION
## Description

* Add support for cosxl and other vpred EDM checkpoints
* Added code to sort the above

Cos Stable Diffusion XL (CosXL) 1.0 Base is tuned to use a Cosine-Continuous EDM VPred schedule. The most notable feature of this schedule change is its capacity to produce the full color range from pitch black to pure white, alongside more subtle improvements to the model's rate-of-change to images across each step.

This improves the colour range considerably over SDXL.

A few models are available on CivitAI at the following link: https://civitai.com/search/models?sortBy=models_v9&query=CosXL
The official model is here: https://huggingface.co/stabilityai/cosxl

Download a model and place it in the normal checkpoint directory and use it as a normal model, no settings changes needed as it's detected by the code change below.

![image](https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/1280021/4d0cc314-c2c3-4b65-8b61-9287af288666)

Example output
![image](https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/1280021/fb0d65a5-8bac-449f-8c4c-26173dac7ddb)

![image](https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/1280021/92368a95-8d7b-48b7-8377-08ae49a6e51b)


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
