### PR TITLE
Restore '/controlnet/control_types' API endpoint

### DIFF
--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/api.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/api.py
@@ -11,6 +11,8 @@ from .global_state import (
     get_all_preprocessor_names,
     get_all_controlnet_names,
     get_preprocessor,
+    get_all_preprocessor_tags,
+    select_control_type,
 )
 from .utils import judge_image_type
 from .logging import logger
@@ -51,6 +53,30 @@ def controlnet_api(_: gr.Blocks, app: FastAPI):
             "module_list": module_list,
             # TODO: Add back module detail.
             # "module_detail": external_code.get_modules_detail(alias_names),
+        }
+
+    @app.get("/controlnet/control_types")
+    async def control_types():
+        def format_control_type(
+            filtered_preprocessor_list,
+            filtered_model_list,
+            default_option,
+            default_model,
+        ):
+            control_dict = {
+                    "module_list": filtered_preprocessor_list,
+                    "model_list": filtered_model_list,
+                    "default_option": default_option,
+                    "default_model": default_model,
+                }
+
+            return control_dict
+
+        return {
+            "control_types": {
+                control_type: format_control_type(*select_control_type(control_type))
+                for control_type in get_all_preprocessor_tags()
+            }
         }
 
     @app.post("/controlnet/detect")


### PR DESCRIPTION
Restores the '/controlnet/control_types' API endpoint, which is immensely useful for anyone using ControlNet via the API

## Description

This endpoint is truly amazing for using ControlNet via API.

I'm an amateur coder, at best, however I'm quite confident that I restored this correctly... I've been using this commit for months on `dev2` / `reForge`

This uses your existing functions as best as possible, I believe, including your filter list and the check for currently loaded SD model version.

Please merge this.

Thank you

## Screenshots/videos:

<img width="1136" alt="Restored" src="https://github.com/lllyasviel/stable-diffusion-webui-forge/assets/1613484/8996c3f2-27be-4405-b0cd-7f05f3eaa2d2">

[response_1714160176770.json](https://github.com/lllyasviel/stable-diffusion-webui-forge/files/15134692/response_1714160176770.json)

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)