### PR TITLE
Fix validation error by updating SDModelItem config field to be optional

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -262,7 +262,7 @@ class SDModelItem(BaseModel):
     hash: Optional[str] = Field(title="Short hash")
     sha256: Optional[str] = Field(title="sha256 hash")
     filename: str = Field(title="Filename")
-    config: Optional[str] = Field(title="Config file")
+    config: Optional[str] = Field(default=None, title="Config file")
 
 class SDVaeItem(BaseModel):
     class Config:


### PR DESCRIPTION
Changed `config` field in `SDModelItem` model to `Optional[str]` with default value `None`.
Without this change, calling /sdapi/v1/sd-models will cause it to crash