### PR TITLE
CLIP was crashing. Fix type error in BLIP model generation by converting configuration values to integers.

### DIFF
--- a/modules/interrogate.py
+++ b/modules/interrogate.py
@@ -178,7 +178,7 @@ class InterrogateModels:
         ])(pil_image).unsqueeze(0).type(self.dtype).to(self.load_device)
 
         with torch.no_grad():
-            caption = self.blip_model.generate(gpu_image, sample=False, num_beams=shared.opts.interrogate_clip_num_beams, min_length=shared.opts.interrogate_clip_min_length, max_length=shared.opts.interrogate_clip_max_length)
+            caption = self.blip_model.generate(gpu_image, sample=False, num_beams=int(shared.opts.interrogate_clip_num_beams), min_length=int(shared.opts.interrogate_clip_min_length), max_length=shared.opts.interrogate_clip_max_length)
 
         return caption[0]
 


### PR DESCRIPTION
Clip was crashing after the new update. To solve it I did:

- Cast `num_beams` and `min_length` to integers in `interrogate.py` when passing them to the BLIP model's `generate` function.
- Resolves issues with type mismatches that caused crashes during the interrogation process.