### PR TITLE
add/fix infotext loading for builtin extensions

### DIFF
--- a/extensions-builtin/sd_forge_kohya_hrfix/scripts/kohya_hrfix.py
+++ b/extensions-builtin/sd_forge_kohya_hrfix/scripts/kohya_hrfix.py
@@ -54,30 +54,43 @@ class KohyaHRFixForForge(scripts.Script):
             downscale_method = gr.Radio(label='Downscale Method', choices=upscale_methods, value=upscale_methods[0])
             upscale_method = gr.Radio(label='Upscale Method', choices=upscale_methods, value=upscale_methods[0])
 
+        self.infotext_fields = [
+            (enabled, lambda d: d.get("kohya_hrfix_enabled", False)),
+            (block_number, "kohya_hrfix_block_number"),
+            (downscale_factor, "kohya_hrfix_downscale_factor"),
+            (start_percent, "kohya_hrfix_start_percent"),
+            (end_percent, "kohya_hrfix_end_percent"),
+            (downscale_after_skip, "kohya_hrfix_downscale_after_skip"),
+            (downscale_method, "kohya_hrfix_downscale_method"),
+            (upscale_method, "kohya_hrfix_upscale_method"),
+        ]
+
         return enabled, block_number, downscale_factor, start_percent, end_percent, downscale_after_skip, downscale_method, upscale_method
+
+    def process(self, p, *script_args, **kwargs):
+        enabled, block_number, downscale_factor, start_percent, end_percent, downscale_after_skip, downscale_method, upscale_method = script_args
+        block_number = int(block_number)
+
+        if enabled:
+            p.extra_generation_params.update(dict(
+                kohya_hrfix_enabled=enabled,
+                kohya_hrfix_block_number=block_number,
+                kohya_hrfix_downscale_factor=downscale_factor,
+                kohya_hrfix_start_percent=start_percent,
+                kohya_hrfix_end_percent=end_percent,
+                kohya_hrfix_downscale_after_skip=downscale_after_skip,
+                kohya_hrfix_downscale_method=downscale_method,
+                kohya_hrfix_upscale_method=upscale_method,
+            ))
+        return
 
     def process_before_every_sampling(self, p, *script_args, **kwargs):
         enabled, block_number, downscale_factor, start_percent, end_percent, downscale_after_skip, downscale_method, upscale_method = script_args
         block_number = int(block_number)
 
-        if not enabled:
-            return
-
-        unet = p.sd_model.forge_objects.unet
-
-        unet = opPatchModelAddDownscale.patch(unet, block_number, downscale_factor, start_percent, end_percent, downscale_after_skip, downscale_method, upscale_method)[0]
-
-        p.sd_model.forge_objects.unet = unet
-
-        p.extra_generation_params.update(dict(
-            kohya_hrfix_enabled=enabled,
-            kohya_hrfix_block_number=block_number,
-            kohya_hrfix_downscale_factor=downscale_factor,
-            kohya_hrfix_start_percent=start_percent,
-            kohya_hrfix_end_percent=end_percent,
-            kohya_hrfix_downscale_after_skip=downscale_after_skip,
-            kohya_hrfix_downscale_method=downscale_method,
-            kohya_hrfix_upscale_method=upscale_method,
-        ))
+        if enabled:
+            unet = p.sd_model.forge_objects.unet
+            unet = opPatchModelAddDownscale.patch(unet, block_number, downscale_factor, start_percent, end_percent, downscale_after_skip, downscale_method, upscale_method)[0]
+            p.sd_model.forge_objects.unet = unet
 
         return

--- a/extensions-builtin/sd_forge_latent_modifier/scripts/forge_latent_modifier.py
+++ b/extensions-builtin/sd_forge_latent_modifier/scripts/forge_latent_modifier.py
@@ -89,45 +89,49 @@ class LatentModifierForForge(scripts.Script):
             self.paste_field_names.append(field.api)
         return enabled, sharpness_multiplier, sharpness_method, tonemap_multiplier, tonemap_method, tonemap_percentile, contrast_multiplier, combat_method, combat_cfg_drift, rescale_cfg_phi, extra_noise_type, extra_noise_method, extra_noise_multiplier, extra_noise_lowpass, divisive_norm_size, divisive_norm_multiplier, spectral_mod_mode, spectral_mod_percentile, spectral_mod_multiplier, affect_uncond, dyn_cfg_augmentation
 
+
+    def process(self, p, *script_args, **kwargs):
+        enabled, sharpness_multiplier, sharpness_method, tonemap_multiplier, tonemap_method, tonemap_percentile, contrast_multiplier, combat_method, combat_cfg_drift, rescale_cfg_phi, extra_noise_type, extra_noise_method, extra_noise_multiplier, extra_noise_lowpass, divisive_norm_size, divisive_norm_multiplier, spectral_mod_mode, spectral_mod_percentile, spectral_mod_multiplier, affect_uncond, dyn_cfg_augmentation = script_args
+
+        if enabled:
+            # Below codes will add some logs to the texts below the image outputs on UI.
+            # The extra_generation_params does not influence results.
+            p.extra_generation_params.update(dict(
+                latent_modifier_enabled=enabled,
+                latent_modifier_sharpness_multiplier=sharpness_multiplier,
+                latent_modifier_sharpness_method=sharpness_method,
+                latent_modifier_tonemap_multiplier=tonemap_multiplier,
+                latent_modifier_tonemap_method=tonemap_method,
+                latent_modifier_tonemap_percentile=tonemap_percentile,
+                latent_modifier_contrast_multiplier=contrast_multiplier,
+                latent_modifier_combat_method=combat_method,
+                latent_modifier_combat_cfg_drift=combat_cfg_drift,
+                latent_modifier_rescale_cfg_phi=rescale_cfg_phi,
+                latent_modifier_extra_noise_type=extra_noise_type,
+                latent_modifier_extra_noise_method=extra_noise_method,
+                latent_modifier_extra_noise_multiplier=extra_noise_multiplier,
+                latent_modifier_extra_noise_lowpass=extra_noise_lowpass,
+                latent_modifier_divisive_norm_size=divisive_norm_size,
+                latent_modifier_divisive_norm_multiplier=divisive_norm_multiplier,
+                latent_modifier_spectral_mod_mode=spectral_mod_mode,
+                latent_modifier_spectral_mod_percentile=spectral_mod_percentile,
+                latent_modifier_spectral_mod_multiplier=spectral_mod_multiplier,
+                latent_modifier_affect_uncond=affect_uncond,
+                latent_modifier_dyn_cfg_augmentation=dyn_cfg_augmentation,
+            ))
+
+        return
+
+
     def process_before_every_sampling(self, p, *script_args, **kwargs):
         # This will be called before every sampling.
         # If you use highres fix, this will be called twice.
 
         enabled, sharpness_multiplier, sharpness_method, tonemap_multiplier, tonemap_method, tonemap_percentile, contrast_multiplier, combat_method, combat_cfg_drift, rescale_cfg_phi, extra_noise_type, extra_noise_method, extra_noise_multiplier, extra_noise_lowpass, divisive_norm_size, divisive_norm_multiplier, spectral_mod_mode, spectral_mod_percentile, spectral_mod_multiplier, affect_uncond, dyn_cfg_augmentation = script_args
 
-        if not enabled:
-            return
-
-        unet = p.sd_model.forge_objects.unet
-
-        unet = opModelSamplerLatentMegaModifier(unet, sharpness_multiplier, sharpness_method, tonemap_multiplier, tonemap_method, tonemap_percentile, contrast_multiplier, combat_method, combat_cfg_drift, rescale_cfg_phi, extra_noise_type, extra_noise_method, extra_noise_multiplier, extra_noise_lowpass, divisive_norm_size, divisive_norm_multiplier, spectral_mod_mode, spectral_mod_percentile, spectral_mod_multiplier, affect_uncond, dyn_cfg_augmentation, seed=p.seeds[0])[0]
-
-        p.sd_model.forge_objects.unet = unet
-
-        # Below codes will add some logs to the texts below the image outputs on UI.
-        # The extra_generation_params does not influence results.
-        p.extra_generation_params.update(dict(
-            latent_modifier_enabled=enabled,
-            latent_modifier_sharpness_multiplier=sharpness_multiplier,
-            latent_modifier_sharpness_method=sharpness_method,
-            latent_modifier_tonemap_multiplier=tonemap_multiplier,
-            latent_modifier_tonemap_method=tonemap_method,
-            latent_modifier_tonemap_percentile=tonemap_percentile,
-            latent_modifier_contrast_multiplier=contrast_multiplier,
-            latent_modifier_combat_method=combat_method,
-            latent_modifier_combat_cfg_drift=combat_cfg_drift,
-            latent_modifier_rescale_cfg_phi=rescale_cfg_phi,
-            latent_modifier_extra_noise_type=extra_noise_type,
-            latent_modifier_extra_noise_method=extra_noise_method,
-            latent_modifier_extra_noise_multiplier=extra_noise_multiplier,
-            latent_modifier_extra_noise_lowpass=extra_noise_lowpass,
-            latent_modifier_divisive_norm_size=divisive_norm_size,
-            latent_modifier_divisive_norm_multiplier=divisive_norm_multiplier,
-            latent_modifier_spectral_mod_mode=spectral_mod_mode,
-            latent_modifier_spectral_mod_percentile=spectral_mod_percentile,
-            latent_modifier_spectral_mod_multiplier=spectral_mod_multiplier,
-            latent_modifier_affect_uncond=affect_uncond,
-            latent_modifier_dyn_cfg_augmentation=dyn_cfg_augmentation,
-        ))
+        if enabled:
+            unet = p.sd_model.forge_objects.unet
+            unet = opModelSamplerLatentMegaModifier(unet, sharpness_multiplier, sharpness_method, tonemap_multiplier, tonemap_method, tonemap_percentile, contrast_multiplier, combat_method, combat_cfg_drift, rescale_cfg_phi, extra_noise_type, extra_noise_method, extra_noise_multiplier, extra_noise_lowpass, divisive_norm_size, divisive_norm_multiplier, spectral_mod_mode, spectral_mod_percentile, spectral_mod_multiplier, affect_uncond, dyn_cfg_augmentation, seed=p.seeds[0])[0]
+            p.sd_model.forge_objects.unet = unet
 
         return

--- a/extensions-builtin/sd_forge_stylealign/scripts/forge_stylealign.py
+++ b/extensions-builtin/sd_forge_stylealign/scripts/forge_stylealign.py
@@ -23,7 +23,23 @@ class StyleAlignForForge(scripts.Script):
         with gr.Accordion(open=False, label=self.title()):
             shared_attention = gr.Checkbox(label='Share attention in batch', value=False)
 
+        self.infotext_fields = [
+            (shared_attention, lambda d: d.get("stylealign_enabled", False)),
+        ]
+
         return [shared_attention]
+
+    def process(self, p, *script_args, **kwargs):
+        shared_attention = script_args[0]
+
+        if shared_attention:
+            # Below codes will add some logs to the texts below the image outputs on UI.
+            # The extra_generation_params does not influence results.
+            p.extra_generation_params.update(dict(
+                stylealign_enabled=shared_attention,
+            ))
+
+        return
 
     def process_before_every_sampling(self, p, *script_args, **kwargs):
         # This will be called before every sampling.
@@ -70,11 +86,5 @@ class StyleAlignForForge(scripts.Script):
         unet.set_model_replace_all(attn1_proc, 'attn1')
 
         p.sd_model.forge_objects.unet = unet
-
-        # Below codes will add some logs to the texts below the image outputs on UI.
-        # The extra_generation_params does not influence results.
-        p.extra_generation_params.update(dict(
-            stylealign_enabled=shared_attention,
-        ))
 
         return


### PR DESCRIPTION
some simple changes, just busy-work really

for eight builtin extensions:
* save settings from process() not process_before_every_sampling() so they are written to params.txt too

for seven builtin extensions (latent modifier not changed):
* add/fix infotext loading (can't use .update with Gradio 4, this method works with v4 and v3)

for freeu:
* dropdown for presets for various sd versions, taken from /ChenyangSi/FreeU
* minor UI tweak, placed pairs of sliders into rows to use less space