### PR TITLE
Fix audio notification for Gradio 4

### DIFF
--- a/javascript/notification.js
+++ b/javascript/notification.js
@@ -26,7 +26,7 @@ onAfterUiUpdate(function() {
     lastHeadImg = headImg;
 
     // play notification sound if available
-    const notificationAudio = gradioApp().querySelector('#audio_notification audio');
+    const notificationAudio = gradioApp().querySelector('#audio_notification #waveform > div')?.shadowRoot?.querySelector('audio');
     if (notificationAudio) {
         notificationAudio.volume = opts.notification_volume / 100.0 || 1.0;
         notificationAudio.play();


### PR DESCRIPTION
The AUDIO element is now in the shadow DOM, so access it there to trigger playback. Closes #1002.

This can be reverted if the AUDIO element is exposed directly again via https://github.com/gradio-app/gradio/issues/8267.