### PR TITLE
MPS doesn't support float64, needs float32

### DIFF
--- a/backend/nn/flux.py
+++ b/backend/nn/flux.py
@@ -19,7 +19,8 @@ def attention(q, k, v, pe):
 
 
 def rope(pos, dim, theta):
-    scale = torch.arange(0, dim, 2, dtype=torch.float64, device=pos.device) / dim
+    dtype = torch.float32 if str(pos.device).startswith("mps") else torch.float64
+    scale = torch.arange(0, dim, 2, dtype=dtype, device=pos.device) / dim
     omega = 1.0 / (theta ** scale)
 
     # out = torch.einsum("...n,d->...nd", pos, omega)


### PR DESCRIPTION
Currently FLUX doesn't work on Macs because it doesn't support float64, but with this simple trick to change the rope method to use float32 on MPS machines, it works, and works pretty well.

Just for reference, this is the error message you get if you run the current code on an MPS machine:

```
Moving model(s) has taken 1.46 seconds
  0%|                                                                                                                                                                                 | 0/4 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/modules_forge/main_thread.py", line 30, in work
    self.result = self.func(*self.args, **self.kwargs)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/modules/txt2img.py", line 110, in txt2img_function
    processed = processing.process_images(p)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/modules/processing.py", line 809, in process_images
    res = process_images_inner(p)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/modules/processing.py", line 952, in process_images_inner
    samples_ddim = p.sample(conditioning=p.c, unconditional_conditioning=p.uc, seeds=p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, prompts=p.prompts)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/modules/processing.py", line 1323, in sample
    samples = self.sampler.sample(self, x, conditioning, unconditional_conditioning, image_conditioning=self.txt2img_image_conditioning(x))
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/modules/sd_samplers_kdiffusion.py", line 234, in sample
    samples = self.launch_sampling(steps, lambda: self.func(self.model_wrap_cfg, x, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/modules/sd_samplers_common.py", line 272, in launch_sampling
    return func()
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/modules/sd_samplers_kdiffusion.py", line 234, in <lambda>
    samples = self.launch_sampling(steps, lambda: self.func(self.model_wrap_cfg, x, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/k_diffusion/sampling.py", line 128, in sample_euler
    denoised = model(x, sigma_hat * s_in, **extra_args)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/modules/sd_samplers_cfg_denoiser.py", line 186, in forward
    denoised, cond_pred, uncond_pred = sampling_function(self, denoiser_params=denoiser_params, cond_scale=cond_scale, cond_composition=cond_composition)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/backend/sampling/sampling_function.py", line 339, in sampling_function
    denoised, cond_pred, uncond_pred = sampling_function_inner(model, x, timestep, uncond, cond, cond_scale, model_options, seed, return_full=True)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/backend/sampling/sampling_function.py", line 284, in sampling_function_inner
    cond_pred, uncond_pred = calc_cond_uncond_batch(model, cond, uncond_, x, timestep, model_options)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/backend/sampling/sampling_function.py", line 254, in calc_cond_uncond_batch
    output = model.apply_model(input_x, timestep_, **c).chunk(batch_chunks)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/backend/modules/k_model.py", line 45, in apply_model
    model_output = self.diffusion_model(xc, t, context=context, control=control, transformer_options=transformer_options, **extra_conds).float()
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/backend/nn/flux.py", line 404, in forward
    out = self.inner_forward(img, img_ids, context, txt_ids, timestep, y, guidance)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/backend/nn/flux.py", line 372, in inner_forward
    pe = self.pe_embedder(ids)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/backend/nn/flux.py", line 84, in forward
    [rope(ids[..., i], self.axes_dim[i], self.theta) for i in range(n_axes)],
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/backend/nn/flux.py", line 84, in <listcomp>
    [rope(ids[..., i], self.axes_dim[i], self.theta) for i in range(n_axes)],
  File "/Users/x/pinokio/api/stable-diffusion-webui-forge.git/app/backend/nn/flux.py", line 24, in rope
    scale = torch.arange(0, dim, 2, dtype=torch.float64, device=pos.device) / dim
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. Please use float32 instead.
Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. Please use float32 instead.
```