### PR TITLE
Remove BasicSR

### DIFF
--- a/extensions-builtin/forge_legacy_preprocessors/annotator/pidinet/model.py
+++ b/extensions-builtin/forge_legacy_preprocessors/annotator/pidinet/model.py
@@ -11,7 +11,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from modules import devices
-from basicsr.utils import img2tensor
 
 nets = {
     'baseline': {
@@ -638,17 +637,3 @@ def pidinet():
     pdcs = config_model('carv4')
     dil = 24 #if args.dil else None
     return PiDiNet(60, pdcs, dil=dil, sa=True)
-
-
-if __name__ == '__main__':
-    model = pidinet()
-    ckp = torch.load('table5_pidinet.pth')['state_dict']
-    model.load_state_dict({k.replace('module.',''):v for k, v in ckp.items()})
-    im = cv2.imread('examples/test_my/cat_v4.png')
-    im = img2tensor(im).unsqueeze(0)/255.
-    res = model(im)[-1]
-    res = res>0.5
-    res = res.float()
-    res = (res[0,0].cpu().data.numpy()*255.).astype(np.uint8)
-    print(res.shape)
-    cv2.imwrite('edge.png', res)

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -33,7 +33,6 @@ torchsde==0.2.6
 transformers==4.44.0
 httpx==0.24.1
 pillow-avif-plugin==1.4.3
-basicsr==1.4.2
 diffusers==0.29.2
 gradio_rangeslider==0.0.6
 tqdm==4.66.1


### PR DESCRIPTION
BasicSR only appears at pidnet main function and it is clearly unnecessary. By requiring the version of basicsr, it's not possible to install dependencies on py311.