### PR TITLE
invalidate cond cache if distilled CFG changed

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -413,6 +413,7 @@ class StableDiffusionProcessing:
 
         return (
             required_prompts,
+            self.distilled_cfg_scale,
             steps,
             hires_steps,
             use_old_scheduling,

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -307,9 +307,9 @@ def create_ui():
 
                     elif category == "cfg":
                         with gr.Row():
-                            distilled_cfg_scale = gr.Slider(minimum=0.0, maximum=30.0, step=0.5, label='Distilled CFG Scale', value=3.5, elem_id="txt2img_distilled_cfg_scale")
+                            distilled_cfg_scale = gr.Slider(minimum=0.0, maximum=30.0, step=0.1, label='Distilled CFG Scale', value=3.5, elem_id="txt2img_distilled_cfg_scale")
                         with gr.Row():
-                            cfg_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.5, label='CFG Scale', value=7.0, elem_id="txt2img_cfg_scale")
+                            cfg_scale = gr.Slider(minimum=1.0, maximum=30.0, step=0.1, label='CFG Scale', value=7.0, elem_id="txt2img_cfg_scale")
                             cfg_scale.change(lambda x: gr.update(interactive=(x != 1)), inputs=[cfg_scale], outputs=[toprow.negative_prompt], queue=False, show_progress=False)
 
                     elif category == "checkboxes":


### PR DESCRIPTION
* adds one line to include distilled_cfg_scale in the parameters that invalidate the cond cache
* two single character changes for step size for distilled CFG and normal CFG, from 0.5 to 0.1 - better control for newer models in my experience. 

https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/1025
https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/1200
