### PR TITLE
minor fixes related to Extras tab

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -82,7 +82,7 @@ function switch_to_inpaint_sketch() {
 }
 
 function switch_to_extras() {
-    gradioApp().querySelector('#tabs').querySelectorAll('button')[2].click();
+    gradioApp().querySelector('#tabs').querySelectorAll('button')[3].click();
 
     return Array.from(arguments);
 }

--- a/modules/postprocessing.py
+++ b/modules/postprocessing.py
@@ -93,7 +93,6 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
 
             if opts.enable_pnginfo:
                 pp.image.info = existing_pnginfo
-                pp.image.info["postprocessing"] = infotext
 
             shared.state.assign_current_image(pp.image)
 

--- a/modules/postprocessing.py
+++ b/modules/postprocessing.py
@@ -24,7 +24,7 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
                     fn = ''
                 else:
                     image = images.read(os.path.abspath(img.name))
-                    fn = os.path.splitext(img.orig_name)[0]
+                    fn = os.path.splitext(img.name)[0]
                 yield image, fn
         elif extras_mode == 2:
             assert not shared.cmd_opts.hide_ui_dir_config, '--hide-ui-dir-config option must be disabled'
@@ -98,7 +98,7 @@ def run_postprocessing(extras_mode, image, image_folder, input_dir, output_dir, 
             shared.state.assign_current_image(pp.image)
 
             if save_output:
-                fullfn, _ = images.save_image(pp.image, path=outpath, basename=basename, extension=opts.samples_format, info=infotext, short_filename=True, no_prompt=True, grid=False, pnginfo_section_name="extras", existing_info=existing_pnginfo, forced_filename=forced_filename, suffix=suffix)
+                fullfn, _ = images.save_image(pp.image, path=outpath, basename=basename, extension=opts.samples_format, info=infotext, short_filename=True, no_prompt=True, grid=False, pnginfo_section_name="postprocessing", existing_info=existing_pnginfo, forced_filename=forced_filename, suffix=suffix)
 
                 if pp.caption:
                     caption_filename = os.path.splitext(fullfn)[0] + ".txt"


### PR DESCRIPTION
1. Send to Extras buttons work as far as sending the image, but do not switch to the Extras tab since the addition of Spaces. Single character change to correct the index used.
2. Extras batch processing fails due to missing attribute 'orig_name'. Corrected to use attribute 'name'. Tested: correctly processes and writes new images preserving the filename if that option is set. Directory processing works too.
3. Postprocessing parameters are written twice, once to PNG section 'postprocessing' and again to 'extras'. Removed one unnecessary line and updated image save to write new text to 'postprocessing' because that's a better name than 'extras'.

Bug not fixed:
single file extras processing doesn't copy generation parameters to the new image (https://github.com/lllyasviel/stable-diffusion-webui-forge/discussions/1204). Maybe something ForgeCanvas doesn't handle? Reverting to old method, using gradio Image, does work but I second-guessed that might be an unwanted change so didn't include it. Does ForgeCanvas have benefits for the Extras tab?
working : **modules/ui_postprocessing.py** : *line 16* :
`extras_image = gr.Image(label="Source", source="upload", interactive=True, type="pil", elem_id="extras_image", height=512)`