### PR TITLE
Variable-Strength StyleAlign

### DIFF
--- a/extensions-builtin/sd_forge_stylealign/scripts/forge_stylealign.py
+++ b/extensions-builtin/sd_forge_stylealign/scripts/forge_stylealign.py
@@ -22,14 +22,15 @@ class StyleAlignForForge(scripts.Script):
     def ui(self, *args, **kwargs):
         with gr.Accordion(open=False, label=self.title()):
             shared_attention = gr.Checkbox(label='Share attention in batch', value=False)
+            strength = gr.Slider(label='Strength', minimum=0.0, maximum=1.0, value=1.0)
 
-        return [shared_attention]
+        return [shared_attention, strength]
 
     def process_before_every_sampling(self, p, *script_args, **kwargs):
         # This will be called before every sampling.
         # If you use highres fix, this will be called twice.
 
-        shared_attention = script_args[0]
+        shared_attention, strength = script_args
 
         if not shared_attention:
             return
@@ -61,8 +62,11 @@ class StyleAlignForForge(scripts.Script):
 
                 if len(indices) > 0:
                     bq, bk, bv = q[indices], k[indices], v[indices]
-                    bo = aligned_attention(bq, bk, bv, transformer_options)
-                    results.append(bo)
+                    original_attention = sdp(bq, bk, bv, transformer_options)
+                    aligned_attention_result = aligned_attention(bq, bk, bv, transformer_options)
+                    # Blend original and aligned attention based on strength
+                    blended_attention = (1.0 - strength) * original_attention + strength * aligned_attention_result
+                    results.append(blended_attention)
 
             results = torch.cat(results, dim=0)
             return results
@@ -75,6 +79,7 @@ class StyleAlignForForge(scripts.Script):
         # The extra_generation_params does not influence results.
         p.extra_generation_params.update(dict(
             stylealign_enabled=shared_attention,
+            stylealign_strength=strength,
         ))
 
         return

--- a/webui-user.bat
+++ b/webui-user.bat
@@ -3,8 +3,8 @@
 set PYTHON=
 set GIT=
 set VENV_DIR=
-set COMMANDLINE_ARGS=
-
+set COMMANDLINE_ARGS=--pin-shared-memory --cuda-malloc --cuda-stream
+ 
 @REM Uncomment following code to reference an existing A1111 checkout.
 @REM set A1111_HOME=Your A1111 checkout dir
 @REM

--- a/webui-user.bat
+++ b/webui-user.bat
@@ -3,8 +3,8 @@
 set PYTHON=
 set GIT=
 set VENV_DIR=
-set COMMANDLINE_ARGS=--pin-shared-memory --cuda-malloc --cuda-stream
- 
+set COMMANDLINE_ARGS=
+
 @REM Uncomment following code to reference an existing A1111 checkout.
 @REM set A1111_HOME=Your A1111 checkout dir
 @REM


### PR DESCRIPTION
Added strength slider for the ratio of StyleAlign applied within a batch. I was finding that my images with StyleAlign replacing the entire attention stack was making output too same-y, especially when trying to generate one subject in different poses within a single run.

Prompt, using Dynamic Prompt for batches, not fixing seed:
_a plate of {salad | pizza | cheeseburgers | bones} with full table setting and a night harbor view_

**At Strength=0 (Equivalent to Off)**
![align-00](https://github.com/user-attachments/assets/4f0bdb50-1cc8-49dc-9bd1-40ae480b4e3e)

**At Strength=0.2**
![align-02](https://github.com/user-attachments/assets/98b5eadf-c63d-4076-8ca2-1767ffd0ebc5)

**At Strength=0.4**
![align-04](https://github.com/user-attachments/assets/73cb7474-2624-44fd-a5cc-ea47a738b979)

**At Strength=0.6**
![align-06](https://github.com/user-attachments/assets/4916ab77-1752-4221-abac-f377d8e135ea)

**At Strength
![align-08](https://github.com/user-attachments/assets/b7698a5d-8ba7-4663-8bc5-975dc6e22b73)
=0.8**

**At Strength=1.0 (Equivalent to Previous Check)**
![align-10](https://github.com/user-attachments/assets/d614ba3e-972a-48af-97a8-69344d30b0f2)