### PR TITLE
bugfix for GET /sdapi/v1/sd-models - solved error about missing a config param

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -721,7 +721,7 @@ class Api:
 
     def get_sd_models(self):
         import modules.sd_models as sd_models
-        return [{"title": x.title, "model_name": x.model_name, "hash": x.shorthash, "sha256": x.sha256, "filename": x.filename} for x in sd_models.checkpoints_list.values()]
+        return [{"title": x.title, "model_name": x.model_name, "hash": x.shorthash, "sha256": x.sha256, "filename": x.filename, "config": getattr(x, 'config', None)} for x in sd_models.checkpoints_list.values()]
 
     def get_sd_vaes(self):
         import modules.sd_vae as sd_vae


### PR DESCRIPTION
get_sd_models now also returning config - fixes the following error:

fastapi.exceptions.ResponseValidationError: 1 validation errors:
  {'type': 'missing', 'loc': ('response', 0, 'config'), 'msg': 'Field required', 'input': {'title': 'realisticVisionV51_v51VAE.safetensors', 'model_name': 'realisticVisionV51_v51VAE', 'hash': None, 'sha256': None, 'filename': 'C:\\Users\\Igor\\Documents\\StableProjectorz\\stable-diffusion-webui-forge\\webui\\models\\Stable-diffusion\\realisticVisionV51_v51VAE.safetensors'}, 'url': 'https://errors.pydantic.dev/2.8/v/missing'}