### PR TITLE
 Fix 1 - FieldInfo object has no attribute type_

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -25,7 +25,7 @@ from modules.textual_inversion.textual_inversion import create_embedding
 from PIL import PngImagePlugin
 from modules.realesrgan_model import get_realesrgan_models
 from modules import devices
-from typing import Any
+from typing import Any, Union, get_origin, get_args
 import piexif
 import piexif.helper
 from contextlib import closing
@@ -371,13 +371,24 @@ class Api:
         set_fields = request.model_dump(exclude_unset=True) if hasattr(request, "request") else request.dict(exclude_unset=True)  # pydantic v1/v2 have different names for this
         params = infotext_utils.parse_generation_parameters(request.infotext)
 
+        def get_base_type(annotation):
+            origin = get_origin(annotation)
+            
+            if origin is Union:             # represents Optional
+                args = get_args(annotation) # filter out NoneType
+                non_none_args = [arg for arg in args if arg is not type(None)]
+                if len(non_none_args) == 1: # annotation was Optional[X]
+                    return non_none_args[0]
+
+            return annotation
+
         def get_field_value(field, params):
             value = field.function(params) if field.function else params.get(field.label)
             if value is None:
                 return None
 
             if field.api in request.__fields__:
-                target_type = request.__fields__[field.api].type_
+                target_type = get_base_type(request.__fields__[field.api].annotation) # extract type from Optional[X]
             else:
                 target_type = type(field.component.value)
 


### PR DESCRIPTION
Fixes https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/993

I am pushing 2 different solutions for the  API error:
`AttributeError: 'FieldInfo' object has no attribute 'type_'`

The other PR: https://github.com/lllyasviel/stable-diffusion-webui-forge/pull/1405

### I do not know which PR is desirable in the new Forge setup.  Please merge one or the other, I trust you will know which is the ideal solution.

This PR gets the same values that previous WebUIs (A1111, old Forge, etc) would get from using `request.__fields__[field.api].type_`

- The `type_` attribute is now replaced with `annotation`
- However, `annotation` returns a typing construct (like `Optional[str]`)
- **This PR extracts the type from the annotation**

### Screenshots with print statements:

**FORGE**

![Forge](https://github.com/user-attachments/assets/2e61dc0d-1233-46b5-806b-d8f0f15b41d6)

**A1111**

![A111](https://github.com/user-attachments/assets/c4a79827-5a1c-43a6-ad3f-8aa68830c433)


### What this PR accomplishes:

**NOTE: I shortened the code for this PR.

![Return original type](https://github.com/user-attachments/assets/b53ad1c7-5ebd-4da6-bb7e-f358bcc055a5)

