### PR TITLE
Fix 2 - FieldInfo object has no attribute type_

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -377,7 +377,7 @@ class Api:
                 return None
 
             if field.api in request.__fields__:
-                target_type = request.__fields__[field.api].type_
+                target_type = request.__fields__[field.api].annotation
             else:
                 target_type = type(field.component.value)
 


### PR DESCRIPTION
Fixes https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/993

I am pushing 2 different solutions for the  API error:
`AttributeError: 'FieldInfo' object has no attribute 'type_'`

The other PR: https://github.com/lllyasviel/stable-diffusion-webui-forge/pull/1406

### I do not know which PR is desirable in the new Forge setup.  Please merge one or the other, I trust you will know which is the ideal solution.

This PR resolves the error, **but does not** return the same values that previous WebUIs (A1111, old Forge, etc) would get from using `request.__fields__[field.api].type_`

- The `type_` attribute is now replaced with `annotation`
- However, `annotation` returns a typing construct (like `Optional[str]`)
- **This PR does NOT try to extract the "type" from the annotation**

### Screenshots with print statements:

**FORGE**

![Forge](https://github.com/user-attachments/assets/2e61dc0d-1233-46b5-806b-d8f0f15b41d6)

**A1111**

![A111](https://github.com/user-attachments/assets/c4a79827-5a1c-43a6-ad3f-8aa68830c433)

