### PR TITLE
bugfix: controlnet works in API - image no longer a dictionary

### DIFF
--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
@@ -211,25 +211,9 @@ class ControlNetUnit:
             **{k: v for k, v in d.items() if k in vars(ControlNetUnit)}
         )
         if isinstance(unit.image, str):
-            img = np.array(api.decode_base64_to_image(unit.image)).astype('uint8')
-            unit.image = {
-                "image": img,
-                "mask": np.zeros_like(img),
-            }
+            unit.image = np.array(api.decode_base64_to_image(unit.image)).astype('uint8')
         if isinstance(unit.mask_image, str):
-            mask = np.array(api.decode_base64_to_image(unit.mask_image)).astype('uint8')
-            if unit.image is not None:
-                # Attach mask on image if ControlNet has input image.
-                assert isinstance(unit.image, dict)
-                unit.image["mask"] = mask
-                unit.mask_image = None
-            else:
-                # Otherwise, wire to standalone mask.
-                # This happens in img2img when using A1111 img2img input.
-                unit.mask_image = {
-                    "image": mask,
-                    "mask": np.zeros_like(mask),
-                }
+            unit.mask_image = np.array(api.decode_base64_to_image(unit.mask_image)).astype('uint8')
         return unit
 
 


### PR DESCRIPTION
Generating from browser works with controlnet. Generating via API didn't.
Because from_dict() was making 'image' and 'mask_image' a dictionary.

In 'controlnet.py' the function 'get_input_data' this would cause exception, because unit.image was of incorrect type:

elif (unit_image < 5).all() and (unit_image_fg > 5).any():

Now, they are never a dictionary and check is fine.
Both browser and api work with controlnet