### PR TITLE
Reimplement Skip Early CFG and NGMS (Negative Guidance Minimum Sigma)

### DIFF
--- a/modules/sd_samplers_cfg_denoiser.py
+++ b/modules/sd_samplers_cfg_denoiser.py
@@ -182,6 +182,19 @@ class CFGDenoiser(torch.nn.Module):
 
         denoiser_params = CFGDenoiserParams(x, image_cond, sigma, state.sampling_step, state.sampling_steps, cond, uncond, self)
         cfg_denoiser_callback(denoiser_params)
+        skip_uncond = False
+
+        if shared.opts.skip_early_cond > 0 and self.step / self.total_steps <= shared.opts.skip_early_cond:
+            skip_uncond = True
+            self.p.extra_generation_params["Skip Early CFG"] = shared.opts.skip_early_cond
+        elif (self.step % 2 or shared.opts.s_min_uncond_all) and s_min_uncond > 0 and sigma[0] < s_min_uncond:
+            skip_uncond = True
+            self.p.extra_generation_params["NGMS"] = s_min_uncond
+            if shared.opts.s_min_uncond_all:
+                self.p.extra_generation_params["NGMS all steps"] = shared.opts.s_min_uncond_all
+
+        if skip_uncond:
+            cond_scale = 1.0
 
         denoised, cond_pred, uncond_pred = sampling_function(self, denoiser_params=denoiser_params, cond_scale=cond_scale, cond_composition=cond_composition)
 


### PR DESCRIPTION
### What does this PR do

- I was searching for `s_min_uncond` in this repo yesterday, and found out that this setting, along with `skip_early_cond`, seem to have never actually worked in Forge. So I referenced the original implementation in Automatic1111 and port them into Forge.

- **TL;DR:** These options skip the negative conditioning during the early and later steps of the diffusion process, in order to speed up the generation.

### Benchmarks

- Running a **SDXL** checkpoint at `1024 x 1024` resolution on <ins>RTX 3060</ins>, using `Euler a` sampler and `Automatic` schedule, with `24` steps and `7.0` CFG Scale, same Seed:

<table>
    <thead align="center">
        <tr>
            <td>Results</td>
            <td><img src="https://github.com/user-attachments/assets/af5b9d0f-74d6-4e16-a5cc-978c1a5cfac2" width=192></td>
            <td><img src="https://github.com/user-attachments/assets/c42859e6-56fd-462a-9ea6-7c51be4b44d3" width=192></td>
            <td><img src="https://github.com/user-attachments/assets/f35cee79-9872-4c83-978f-18d189e20481" width=192></td>
        </tr>
    </thead>
    <tbody align="center">
        <tr>
            <td>Time</td>
            <td>15s</td>
            <td>12s</td>
            <td>9s</td>
        </tr>
        <tr>
            <td>s_min_uncond</td>
            <td>0.0</td>
            <td>1.0</td>
            <td>2.0</td>
        </tr>
        <tr>
            <td>s_min_uncond_all</td>
            <td>False</td>
            <td>False</td>
            <td>True</td>
        </tr>
        <tr>
            <td>skip_early_cond</td>
            <td>0.0</td>
            <td>0.1</td>
            <td>0.2</td>
        </tr>
    </tbody>
</table>

<hr>

- This won't speed up **Flux** checkpoints, as negative prompt is disabled for Flux (by default)

- To be perfectly honest, I don't know how to work with Forge's `cond` / `uncond` to replicate the implementation in Automatic1111. But setting `cond_scale` to `1.0` seems to achieve more or less the same effect.