### PR TITLE
Add API endpoint [GET] 'sd-text-encoders'

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -224,6 +224,7 @@ class Api:
         self.add_api_route("/sdapi/v1/latent-upscale-modes", self.get_latent_upscale_modes, methods=["GET"], response_model=list[models.LatentUpscalerModeItem])
         self.add_api_route("/sdapi/v1/sd-models", self.get_sd_models, methods=["GET"], response_model=list[models.SDModelItem])
         self.add_api_route("/sdapi/v1/sd-vae", self.get_sd_vaes, methods=["GET"], response_model=list[models.SDVaeItem])
+        self.add_api_route("/sdapi/v1/sd-text-encoders", self.get_sd_text_encoders, methods=["GET"], response_model=list[models.SDTextEncoderItem])
         self.add_api_route("/sdapi/v1/hypernetworks", self.get_hypernetworks, methods=["GET"], response_model=list[models.HypernetworkItem])
         self.add_api_route("/sdapi/v1/face-restorers", self.get_face_restorers, methods=["GET"], response_model=list[models.FaceRestorerItem])
         self.add_api_route("/sdapi/v1/realesrgan-models", self.get_realesrgan_models, methods=["GET"], response_model=list[models.RealesrganItem])
@@ -737,6 +738,21 @@ class Api:
     def get_sd_vaes(self):
         import modules.sd_vae as sd_vae
         return [{"model_name": x, "filename": sd_vae.vae_dict[x]} for x in sd_vae.vae_dict.keys()]
+
+    def get_sd_text_encoders(self):
+        from modules import paths
+        from modules_forge.main_entry import find_files_with_extensions
+        text_encoder_paths = [
+            os.path.abspath(os.path.join(paths.models_path, "text_encoder")),
+        ]
+        if isinstance(shared.cmd_opts.vae_dir, str): # TODO shared.cmd_opts.text_encoder_dir?
+            text_encoder_paths.append(os.path.abspath(shared.cmd_opts.vae_dir))
+        file_extensions = ['ckpt', 'pt', 'bin', 'safetensors']
+        text_encoders = {}
+        for text_encoder_path in text_encoder_paths:
+            found = find_files_with_extensions(text_encoder_path, file_extensions)
+            text_encoders.update(found)
+        return [{"model_name": name, "filename": path} for name, path in text_encoders.items()]
 
     def get_hypernetworks(self):
         return [{"name": name, "path": shared.hypernetworks[name]} for name in shared.hypernetworks]

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -271,6 +271,13 @@ class SDVaeItem(BaseModel):
     model_name: str = Field(title="Model Name")
     filename: str = Field(title="Filename")
 
+class SDTextEncoderItem(BaseModel):
+    class Config:
+        protected_namespaces = ()
+
+    model_name: str = Field(title="Model Name")
+    filename: str = Field(title="Filename")
+
 class HypernetworkItem(BaseModel):
     name: str = Field(title="Name")
     path: Optional[str] = Field(title="Path")


### PR DESCRIPTION
This API call should be useful soon, if not immediately.

This implementation is *kind of* sloppy, since **text_encoders** are not handled particularly graceful (yet).

As, far as I can tell, **text_encoders** are currently only fetched for the UI via **[refresh_models](https://github.com/lllyasviel/stable-diffusion-webui-forge/blob/df598c4df5ee8c6c6b12f1cd4c78043c6192cde2/modules_forge/main_entry.py#L136)** - lumped in with VAEs.

Meanwhile, **[get_sd_vaes](https://github.com/lllyasviel/stable-diffusion-webui-forge/blob/df598c4df5ee8c6c6b12f1cd4c78043c6192cde2/modules/api/api.py#L737)** endpoint has the dedicated [sdvae module](https://github.com/lllyasviel/stable-diffusion-webui-forge/blob/df598c4df5ee8c6c6b12f1cd4c78043c6192cde2/modules/sd_vae.py) to fetch from (which does not manage / return **text-encoders** at all).

I am a bit of an amateur, so I do not know how a **text_encoders module** could be fleshed out and put to good use.

In the meantime, this solution just uses **[find_files_with_extensions](https://github.com/lllyasviel/stable-diffusion-webui-forge/blob/f23ee63cb340504c15607cc68798cd28abb88037/modules_forge/main_entry.py#L126)** to populate the dictionary.

---

**Known bug:** Since `shared.cmd_opts.vae_dir` is a mixture of VAE/Text Encoders - by this API call including those directories, it will likely return normal VAE checkpoints if `--vae_dir` CMD Arg is passed.

```
        if isinstance(shared.cmd_opts.vae_dir, str): # TODO shared.cmd_opts.text_encoder_dir?
            text_encoder_paths.append(os.path.abspath(shared.cmd_opts.vae_dir))
```

**Possible solutions**
- Improve separation for **text_encoders** from **VAEs**
  - Add a new CMD Arg explicitly for `--text_encoders_dir` and use it in the API function.
  - Update **[refresh_models](https://github.com/lllyasviel/stable-diffusion-webui-forge/blob/df598c4df5ee8c6c6b12f1cd4c78043c6192cde2/modules_forge/main_entry.py#L136)** to collect both lists and merge them for the UI.

OR

- Just omit the 2 lines regarding `--var_dir` (Do not allow getting these text_encoders via API)

---

![get_text_encoders](https://github.com/user-attachments/assets/c2bdca25-8377-4dbc-b45d-a7842e7db31b)

