### PR TITLE
Correct commit_date type to 'int'

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -332,5 +332,5 @@ class ExtensionItem(BaseModel):
     branch: str = Field(title="Branch", description="Extension Repository Branch")
     commit_hash: str = Field(title="Commit Hash", description="Extension Repository Commit Hash")
     version: str = Field(title="Version", description="Extension Version")
-    commit_date: str = Field(title="Commit Date", description="Extension Repository Commit Date")
+    commit_date: int = Field(title="Commit Date", description="Extension Repository Commit Date")
     enabled: bool = Field(title="Enabled", description="Flag specifying whether this extension is enabled")


### PR DESCRIPTION
Resolves https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/922

@dermesut said it worked if using `int` instead of `str`, so I added debug printing to confirm.

Yes, `commit_date` is definitely an `int`

<img width="848" alt="Screenshot 2024-08-24 211244" src="https://github.com/user-attachments/assets/d7229747-072d-4c8d-a1e5-6eb5b16bdc9e">

Error resolved by changing `commit_date: str` to `commit_date: int`

<img width="1091" alt="Screenshot 2024-08-24 211617" src="https://github.com/user-attachments/assets/4a388aaf-628c-43e0-93af-53046651586b">
