### PR TITLE
Apply settings in ui-config.json to "All" presets

### DIFF
--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -62,7 +62,7 @@ def make_checkpoint_manager_ui():
         if len(sd_models.checkpoints_list) > 0:
             shared.opts.set('sd_model_checkpoint', next(iter(sd_models.checkpoints_list.values())).name)
 
-    ui_forge_preset = gr.Radio(label="UI", value=lambda: shared.opts.forge_preset, choices=['sd', 'xl', 'flux', 'ui-config', 'all'])
+    ui_forge_preset = gr.Radio(label="UI", value=lambda: shared.opts.forge_preset, choices=['sd', 'xl', 'flux', 'all'])
 
     ckpt_list, vae_list = refresh_models()
 
@@ -363,30 +363,8 @@ def on_preset_change(preset=None):
             gr.update(value='Simple'),  # ui_img2img_scheduler
         ]
 
-    if shared.opts.forge_preset == 'ui-config':
-        loadsave = ui_loadsave.UiLoadsave(cmd_opts.ui_config_file)
-        ui_settings_from_file = loadsave.ui_settings.copy()
-
-        return [
-            gr.update(visible=True),  # ui_vae
-            gr.update(visible=True, value=1),  # ui_clip_skip
-            gr.update(visible=True, value='Automatic'),  # ui_forge_unet_storage_dtype_options
-            gr.update(visible=True, value='Queue'),  # ui_forge_async_loading
-            gr.update(visible=True, value='CPU'),  # ui_forge_pin_shared_memory
-            gr.update(visible=True, value=total_vram - 1024),  # ui_forge_inference_memory
-            gr.update(value=ui_settings_from_file['txt2img/Width/value']),  # ui_txt2img_width
-            gr.update(value=ui_settings_from_file['img2img/Width/value']),  # ui_img2img_width
-            gr.update(value=ui_settings_from_file['txt2img/Height/value']),  # ui_txt2img_height
-            gr.update(value=ui_settings_from_file['img2img/Height/value']),  # ui_img2img_height
-            gr.update(value=ui_settings_from_file['txt2img/CFG Scale/value']),  # ui_txt2img_cfg
-            gr.update(value=ui_settings_from_file['img2img/CFG Scale/value']),  # ui_img2img_cfg
-            gr.update(visible=True, value=ui_settings_from_file['txt2img/Distilled CFG Scale/value']),  # ui_txt2img_distilled_cfg
-            gr.update(visible=True, value=ui_settings_from_file['img2img/Distilled CFG Scale/value']),  # ui_img2img_distilled_cfg
-            gr.update(value=ui_settings_from_file['customscript/sampler.py/txt2img/Sampling method/value']),  # ui_txt2img_sampler
-            gr.update(value=ui_settings_from_file['customscript/sampler.py/img2img/Sampling method/value']),  # ui_img2img_sampler
-            gr.update(value=ui_settings_from_file['customscript/sampler.py/txt2img/Schedule type/value']),  # ui_txt2img_scheduler
-            gr.update(value=ui_settings_from_file['customscript/sampler.py/img2img/Schedule type/value']),  # ui_img2img_scheduler
-        ]
+    loadsave = ui_loadsave.UiLoadsave(cmd_opts.ui_config_file)
+    ui_settings_from_file = loadsave.ui_settings.copy()
 
     return [
         gr.update(visible=True),  # ui_vae
@@ -395,16 +373,16 @@ def on_preset_change(preset=None):
         gr.update(visible=True, value='Queue'),  # ui_forge_async_loading
         gr.update(visible=True, value='CPU'),  # ui_forge_pin_shared_memory
         gr.update(visible=True, value=total_vram - 1024),  # ui_forge_inference_memory
-        gr.update(value=896),  # ui_txt2img_width
-        gr.update(value=1024),  # ui_img2img_width
-        gr.update(value=1152),  # ui_txt2img_height
-        gr.update(value=1024),  # ui_img2img_height
-        gr.update(value=7),  # ui_txt2img_cfg
-        gr.update(value=7),  # ui_img2img_cfg
-        gr.update(visible=True, value=3.5),  # ui_txt2img_distilled_cfg
-        gr.update(visible=True, value=3.5),  # ui_img2img_distilled_cfg
-        gr.update(value='DPM++ 2M'),  # ui_txt2img_sampler
-        gr.update(value='DPM++ 2M'),  # ui_img2img_sampler
-        gr.update(value='Automatic'),  # ui_txt2img_scheduler
-        gr.update(value='Automatic'),  # ui_img2img_scheduler
+        gr.update(value=ui_settings_from_file['txt2img/Width/value']),  # ui_txt2img_width
+        gr.update(value=ui_settings_from_file['img2img/Width/value']),  # ui_img2img_width
+        gr.update(value=ui_settings_from_file['txt2img/Height/value']),  # ui_txt2img_height
+        gr.update(value=ui_settings_from_file['img2img/Height/value']),  # ui_img2img_height
+        gr.update(value=ui_settings_from_file['txt2img/CFG Scale/value']),  # ui_txt2img_cfg
+        gr.update(value=ui_settings_from_file['img2img/CFG Scale/value']),  # ui_img2img_cfg
+        gr.update(visible=True, value=ui_settings_from_file['txt2img/Distilled CFG Scale/value']),  # ui_txt2img_distilled_cfg
+        gr.update(visible=True, value=ui_settings_from_file['img2img/Distilled CFG Scale/value']),  # ui_img2img_distilled_cfg
+        gr.update(value=ui_settings_from_file['customscript/sampler.py/txt2img/Sampling method/value']),  # ui_txt2img_sampler
+        gr.update(value=ui_settings_from_file['customscript/sampler.py/img2img/Sampling method/value']),  # ui_img2img_sampler
+        gr.update(value=ui_settings_from_file['customscript/sampler.py/txt2img/Schedule type/value']),  # ui_txt2img_scheduler
+        gr.update(value=ui_settings_from_file['customscript/sampler.py/img2img/Schedule type/value']),  # ui_img2img_scheduler
     ]

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -3,9 +3,10 @@ import torch
 import gradio as gr
 
 from gradio.context import Context
-from modules import shared_items, shared, ui_common, sd_models, processing, infotext_utils, paths
+from modules import shared_items, shared, ui_common, sd_models, processing, infotext_utils, paths, ui_loadsave
 from backend import memory_management, stream
 from backend.args import dynamic_args
+from modules.shared import cmd_opts
 
 
 total_vram = int(memory_management.total_vram)
@@ -20,6 +21,8 @@ ui_forge_unet_storage_dtype_options: gr.Radio = None
 ui_forge_async_loading: gr.Radio = None
 ui_forge_pin_shared_memory: gr.Radio = None
 ui_forge_inference_memory: gr.Slider = None
+
+
 
 forge_unet_storage_dtype_options = {
     'Automatic': (None, False),
@@ -59,7 +62,7 @@ def make_checkpoint_manager_ui():
         if len(sd_models.checkpoints_list) > 0:
             shared.opts.set('sd_model_checkpoint', next(iter(sd_models.checkpoints_list.values())).name)
 
-    ui_forge_preset = gr.Radio(label="UI", value=lambda: shared.opts.forge_preset, choices=['sd', 'xl', 'flux', 'all'])
+    ui_forge_preset = gr.Radio(label="UI", value=lambda: shared.opts.forge_preset, choices=['sd', 'xl', 'flux', 'ui-config', 'all'])
 
     ckpt_list, vae_list = refresh_models()
 
@@ -358,6 +361,31 @@ def on_preset_change(preset=None):
             gr.update(value='Euler'),  # ui_img2img_sampler
             gr.update(value='Simple'),  # ui_txt2img_scheduler
             gr.update(value='Simple'),  # ui_img2img_scheduler
+        ]
+
+    if shared.opts.forge_preset == 'ui-config':
+        loadsave = ui_loadsave.UiLoadsave(cmd_opts.ui_config_file)
+        ui_settings_from_file = loadsave.ui_settings.copy()
+
+        return [
+            gr.update(visible=True),  # ui_vae
+            gr.update(visible=True, value=1),  # ui_clip_skip
+            gr.update(visible=True, value='Automatic'),  # ui_forge_unet_storage_dtype_options
+            gr.update(visible=True, value='Queue'),  # ui_forge_async_loading
+            gr.update(visible=True, value='CPU'),  # ui_forge_pin_shared_memory
+            gr.update(visible=True, value=total_vram - 1024),  # ui_forge_inference_memory
+            gr.update(value=ui_settings_from_file['txt2img/Width/value']),  # ui_txt2img_width
+            gr.update(value=ui_settings_from_file['img2img/Width/value']),  # ui_img2img_width
+            gr.update(value=ui_settings_from_file['txt2img/Height/value']),  # ui_txt2img_height
+            gr.update(value=ui_settings_from_file['img2img/Height/value']),  # ui_img2img_height
+            gr.update(value=ui_settings_from_file['txt2img/CFG Scale/value']),  # ui_txt2img_cfg
+            gr.update(value=ui_settings_from_file['img2img/CFG Scale/value']),  # ui_img2img_cfg
+            gr.update(visible=True, value=ui_settings_from_file['txt2img/Distilled CFG Scale/value']),  # ui_txt2img_distilled_cfg
+            gr.update(visible=True, value=ui_settings_from_file['img2img/Distilled CFG Scale/value']),  # ui_img2img_distilled_cfg
+            gr.update(value=ui_settings_from_file['customscript/sampler.py/txt2img/Sampling method/value']),  # ui_txt2img_sampler
+            gr.update(value=ui_settings_from_file['customscript/sampler.py/img2img/Sampling method/value']),  # ui_img2img_sampler
+            gr.update(value=ui_settings_from_file['customscript/sampler.py/txt2img/Schedule type/value']),  # ui_txt2img_scheduler
+            gr.update(value=ui_settings_from_file['customscript/sampler.py/img2img/Schedule type/value']),  # ui_img2img_scheduler
         ]
 
     return [


### PR DESCRIPTION
Added a preset “ui-config” that loads settings stored in ui-config.json.
This allows users to specify and save default values in the traditional way.

The settings to be loaded are the following items
- txt2img/Width/value
- txt2img/Height/value
- txt2img/CFG Scale/value
- txt2img/Distilled CFG Scale/value
- customscript/sampler.py/txt2img/Sampling method/value
- customscript/sampler.py/txt2img/Schedule type/value
- img2img/Width/value
- img2img/Height/value
- img2img/CFG Scale/value
- img2img/Distilled CFG Scale/value
- customscript/sampler.py/img2img/Sampling method/value
- customscript/sampler.py/img2img/Schedule type/value

This modification is related to the following issues
https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/1323