### PR TITLE
add 'Lora hashes' to infotext fields that can be ignored

### DIFF
--- a/modules/shared_items.py
+++ b/modules/shared_items.py
@@ -85,6 +85,8 @@ def get_infotext_names():
             if isinstance(name, str):
                 res[name] = 1
 
+    res['Lora hashes'] = 1
+
     return list(res)
 
 


### PR DESCRIPTION
In *Settings -> Disregard fields from pasted infotext* there is a very long list of things that can optionally be ignored when parsing infotext. Now it is a longer list by one, and includes `Lora hashes`.