### PR TITLE
Adjust Checkpoint input style

### DIFF
--- a/style.css
+++ b/style.css
@@ -443,6 +443,11 @@ div.toprow-compact-tools{
     min-width: 20em !important;
 }
 
+#quicksettings > div.model_selection input{
+    margin-right: 2.5em !important;
+    text-align: right !important;
+}
+
 #quicksettings .subdued{
     display: block;
     margin-left: auto;

--- a/style.css
+++ b/style.css
@@ -444,8 +444,8 @@ div.toprow-compact-tools{
 }
 
 #quicksettings > div.model_selection input{
-    margin-right: 2.5em !important;
-    text-align: right !important;
+    width: 85% !important; /* Ensure the input field is never chopped off */
+    margin-left: 2% !important; /* override the margin set for subdued */
 }
 
 #quicksettings .subdued{

--- a/style.css
+++ b/style.css
@@ -448,6 +448,11 @@ div.toprow-compact-tools{
     margin-left: 2% !important; /* override the margin set for subdued */
 }
 
+#quicksettings > div.model_selection li{
+    overflow-x: visible !important;
+    width: 100% !important; /* Set size to max element */
+}
+
 #quicksettings .subdued{
     display: block;
     margin-left: auto;


### PR DESCRIPTION
Slight adjustments to the Checkpoint dropdown in response to #1586 .

I would appreciate feedback from UX/UI folks, I think that these changes allow the filtering input to not overlap the dropdown arrow, but the right-align might be too much.

Current Filtering
![image](https://github.com/user-attachments/assets/42cfddeb-f285-49b4-a6b4-3bbab8a909e4)

Updated Filtering (See Below)


Current Long Checkpoint Listing
![image](https://github.com/user-attachments/assets/0f7a0bc1-7e59-4c06-b0f9-27073adfdcb5)

Updated Long Checkpoint Listing (See below)

Current Short Checkpoint Listing
![image](https://github.com/user-attachments/assets/9da1bf8b-2790-44e9-9ee0-492689da7484)

Updated Short Checkpoint Listing (See below)


Additionally, not sure what the best way to address the ul.options formatting, I think adjusting them to right aligned would address the issue, but unsure if that is desired.
