### PR TITLE
Make sure script modules get added to sys.modules

### DIFF
--- a/modules/script_loading.py
+++ b/modules/script_loading.py
@@ -1,4 +1,4 @@
-import os
+import os, sys
 import importlib.util
 
 from modules import errors
@@ -10,6 +10,11 @@ loaded_scripts = {}
 def load_module(path):
     module_spec = importlib.util.spec_from_file_location(os.path.basename(path), path)
     module = importlib.util.module_from_spec(module_spec)
+    # see importlib docs, module must be added to sys.modules
+    # https://docs.python.org/3/library/importlib.html#examples
+    # See dicussion https://github.com/python/cpython/issues/81702
+    if module_spec.name not in sys.modules:
+        sys.modules[module_spec.name] = module
     module_spec.loader.exec_module(module)
 
     loaded_scripts[path] = module


### PR DESCRIPTION
Long existing bug that Gradio 4 uncovered mainly in extensions.  The [importlib docs](https://docs.python.org/3/library/importlib.html#examples) (and [relevant cpython issue](https://github.com/python/cpython/issues/81702)) detail the need to add the module created from spec to the `sys.modules` list.

More details, new in Gradio 4, the new `Component` base class `ComponentBase` [explicitly uses](https://github.com/gradio-app/gradio/blob/main/gradio/components/base.py#L116) the file containing a component for an id value.  For certain extensions that subclassed a Gradio `Componen`t this could lead to the extension failing to load due to the above Gradio code.  See examples [here](https://github.com/LEv145/--sd-webui-ar-plus/issues/24) and [here](https://github.com/hako-mikan/sd-webui-cd-tuner/pull/29).

Should address issues #1605, part of #1599, and #1466