### PR TITLE
reactivated the old hashing that work for civitai

### DIFF
--- a/modules/hashes.py
+++ b/modules/hashes.py
@@ -20,7 +20,8 @@ def calculate_sha256_real(filename):
 
 
 def calculate_sha256(filename):
-    return forge_fake_calculate_sha256(filename)
+    print("calculating real hash")
+    return calculate_sha256_real(filename)
 
 
 def forge_fake_calculate_sha256(filename):
@@ -60,7 +61,7 @@ def sha256(filename, title, use_addnet_hash=False):
         return None
 
     print(f"Calculating sha256 for {filename}: ", end='')
-    sha256_value = forge_fake_calculate_sha256(filename)
+    sha256_value = calculate_sha256_real(filename)
     print(f"{sha256_value}")
 
     hashes[title] = {

--- a/modules/hashes.py
+++ b/modules/hashes.py
@@ -20,7 +20,7 @@ def calculate_sha256_real(filename):
 
 
 def calculate_sha256(filename):
-    print("calculating real hash")
+    print("Calculating real hash: ", filename)
     return calculate_sha256_real(filename)
 
 
@@ -60,7 +60,7 @@ def sha256(filename, title, use_addnet_hash=False):
     if shared.cmd_opts.no_hashing:
         return None
 
-    print(f"Calculating sha256 for {filename}: ", end='')
+    print(f"Calculating sha256 for {filename}: ", end='', flush=True)
     sha256_value = calculate_sha256_real(filename)
     print(f"{sha256_value}")
 


### PR DESCRIPTION
This pull request reactivates existing code in _hashes.py that was previously commented out or disabled.

### Issue
The current hashing function does not correctly identify resources on Civitai. As a result, checkpoints (both Stable Diffusion and Flux) and Loras (only Stable Diffusion) are not recognized.

### Fix: 
By reactivating the original hashing function, the recognition of these resources is restored:

1. Flux Checkpoints: Now recognized correctly.

2. Stable Diffusion Models: Both checkpoints and Loras are correctly recognized.

### Impact
**Before the Fix:**
Using the current fake hashing function, no resources are recognized.
![fake_hash](https://github.com/user-attachments/assets/0a2df22e-1b3e-44bf-bb96-5d06ad4e4b35)

**After the Fix:**

1. The Flux checkpoint is recognized, though Loras for Flux models are still not recognized.

![good old hash](https://github.com/user-attachments/assets/caa36990-f61d-4163-932a-0b0393144b22)

2. For Stable Diffusion models, both checkpoints and Loras are correctly recognized.
![pony](https://github.com/user-attachments/assets/88526de3-f346-460e-a719-a3ccb4a7ce6a)
