### PR TITLE
Set controlllite module dtype to model dtype

### DIFF
--- a/extensions-builtin/sd_forge_controlllite/lib_controllllite/lib_controllllite.py
+++ b/extensions-builtin/sd_forge_controlllite/lib_controllllite/lib_controllllite.py
@@ -214,8 +214,6 @@ class LLLiteModule(torch.nn.Module):
 
         if self.cond_emb is None:
             # print(f"cond_emb is None, {self.name}")
-            # test bad idea
-            #self.cond_image = self.cond_image.view(dtype=x.dtype)
             cx = self.conditioning1(self.cond_image.to(x.device, dtype=x.dtype))
             if not self.is_conv2d:
                 # reshape / b,c,h,w -> b,h*w,c

--- a/extensions-builtin/sd_forge_controlllite/lib_controllllite/lib_controllllite.py
+++ b/extensions-builtin/sd_forge_controlllite/lib_controllllite/lib_controllllite.py
@@ -267,7 +267,7 @@ class LLLiteLoader:
 
         model_lllite = model.clone()
         patch = load_control_net_lllite_patch(state_dict, cond_image, strength, steps, start_percent, end_percent,
-                                              model_lllite.model.storage_dtype)
+                                              model.model.diffusion_model.computation_dtype)
         if patch is not None:
             model_lllite.set_model_attn1_patch(patch)
             model_lllite.set_model_attn2_patch(patch)

--- a/extensions-builtin/sd_forge_controlllite/lib_controllllite/lib_controllllite.py
+++ b/extensions-builtin/sd_forge_controlllite/lib_controllllite/lib_controllllite.py
@@ -136,7 +136,6 @@ class LLLiteModule(torch.nn.Module):
         self.start_step = start_step
         self.end_step = end_step
         self.is_first = False
-        self.dtype = dtype
 
         modules = []
         modules.append(torch.nn.Conv2d(3, cond_emb_dim // 2, kernel_size=4, stride=4, padding=0))  # to latent (from VAE) size*2


### PR DESCRIPTION
Sets the dtype of the controlllite controlnet to match the dtype of the model; addresses issue reported in #1641 #1488 #1392 for builtin kohya controlllite models and the [bdsqlsz](https://huggingface.co/bdsqlsz/qinglong_controlnet-lllite) models as far as I can tell (hopefully other controlllite's as well).

Full disclosure, I'm not sure what the quality consequences of changing the dtype, only that this change causes the error to go away.  Would appreciate @DenOfEquity's eyes on this since they reported not being able to reproduce the issue.

 No cnet (Base Model: protovisionXL)
 
![image](https://github.com/user-attachments/assets/fadb5c13-f3f2-4aee-954e-0cc665a28659)

Control Image

![image](https://github.com/user-attachments/assets/12ddedc8-9a41-4622-a8a5-f8ab410ef15e)

Depth Kohya_controlllite

![image](https://github.com/user-attachments/assets/bccd0cfd-96da-43dc-887d-2334732991f7)
![image](https://github.com/user-attachments/assets/592aa580-26e5-4b1a-87af-5cf169cd2c4d)

Depth bdsqlsz

![image](https://github.com/user-attachments/assets/0fc104aa-7826-4734-85ff-8368d993c83e)

Canny bdsqlsz

![image](https://github.com/user-attachments/assets/82ae2e11-4b57-4c1e-8415-c664ac6cec37)
![image](https://github.com/user-attachments/assets/c998831b-cef0-4915-81ed-718fa6b99a13)

