### PR TITLE
img2img subtabs: preserve user drawing

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -585,11 +585,17 @@ def create_ui():
                             for i, tab in enumerate(img2img_tabs):
                                 tab.select(fn=lambda tabnum=i: tabnum, inputs=[], outputs=[img2img_selected_tab])
 
+                        def copyCanvas_img2img (background, foreground, source):
+                            if source == 1 or source == 3: #   1 is sketch, 3 is Inpaint sketch
+                                bg = Image.alpha_composite(background, foreground)
+                                return bg, None
+                            return background, None
+
                         for button, name, elem in copy_image_buttons:
                             button.click(
-                                fn=lambda img: img,
-                                inputs=[elem.background],
-                                outputs=[copy_image_destinations[name].background],
+                                fn=copyCanvas_img2img,
+                                inputs=[elem.background, elem.foreground, img2img_selected_tab],
+                                outputs=[copy_image_destinations[name].background, copy_image_destinations[name].foreground],
                             )
                             button.click(
                                 fn=None,


### PR DESCRIPTION
Currently, copying between img2img sub-tabs copies only the background. If the user has drawn, that is not copied. This PR flattens foreground onto background when copying from *Sketch* and *Inpaint sketch*, but not from *Inpaint* as that is likely to be high-contrast squares and/or not a drawing anyway.
I tested copying foreground and background without flattening but this becomes flaky with repeated copies.

#1497