### PR TITLE
Update style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -444,8 +444,12 @@ div.toprow-compact-tools{
 }
 
 #quicksettings > div.model_selection input{
-    width: 85% !important; /* Ensure the input field is never chopped off */
     margin-left: 2% !important; /* override the margin set for subdued */
+}
+
+#quicksettings .icon-wrap {
+    margin-right: -4% !important;
+    background-color: var(--background-fill-secondary);
 }
 
 #quicksettings > div.model_selection li{


### PR DESCRIPTION
The previous change to the width of the Checkpoint input box, to prevent overlap between long checkpoint names and the dropdown arrow, also reduced the clickable region of the input box - showing up the arrow as the purely visual element that it is. This PR restores width, tweaks position of the arrow to the right, and makes the arrow background solid to avoid interference with model name text. The latter two changes also affect the vae/te and diffusion in low bits menus.

#1693