### PR TITLE
style.css: model dropdown edge case

### DIFF
--- a/style.css
+++ b/style.css
@@ -445,6 +445,7 @@ div.toprow-compact-tools{
 
 #quicksettings > div.model_selection input{
     margin-left: 2% !important; /* override the margin set for subdued */
+    width: 100%;
 }
 
 #quicksettings .icon-wrap {


### PR DESCRIPTION
why *is* CSS?
#1707 Seems like empty input inherited small width from *.subdued* and therefore only an equally small section was clickable to drop the menu. Bit of an edge-case.