### PR TITLE
[Spaces] Check for requirement regardless of repo_id

### DIFF
--- a/modules_forge/forge_space.py
+++ b/modules_forge/forge_space.py
@@ -132,6 +132,12 @@ class ForgeSpace:
         os.makedirs(self.hf_path, exist_ok=True)
 
         if self.repo_id is None:
+            requirements_filename = os.path.abspath(os.path.realpath(os.path.join(self.root_path, 'requirements.txt')))
+
+            if os.path.exists(requirements_filename):
+                from modules.launch_utils import run_pip
+                run_pip(f'install -r "{requirements_filename}"', desc=f"space requirements for [{self.title}]")
+
             return self.refresh_gradio()
 
         downloaded = snapshot_download(


### PR DESCRIPTION
Right now, if you create a **Forge Space** that is not based on an existing **Hugging Face Space** *(`repo_id` = `null`)*, the `requirements.txt` is not checked at all. So I added another check before finishing the installation.

**Note:** I added it this way instead of moving the whole thing up, because I think some **Space**s will download a `requirements.txt` of its own, so the check for them still has to happen later. 