### PR TITLE
[Space] Add the ability to reinstall requirements specifically

### DIFF
--- a/modules_forge/forge_space.py
+++ b/modules_forge/forge_space.py
@@ -131,16 +131,15 @@ class ForgeSpace:
         return results
 
     def install(self):
-        installed = os.path.exists(self.hf_path)
         os.makedirs(self.hf_path, exist_ok=True)
 
-        if self.repo_id is not None and not installed:
+        if self.repo_id is not None:
             downloaded = snapshot_download(
                 repo_id=self.repo_id,
                 repo_type=self.repo_type,
                 revision=self.revision,
                 local_dir=self.hf_path,
-                force_download=True,
+                force_download=False,
                 allow_patterns=self.allow_patterns,
                 ignore_patterns=self.ignore_patterns
             )

--- a/modules_forge/forge_space.py
+++ b/modules_forge/forge_space.py
@@ -116,22 +116,25 @@ class ForgeSpace:
         results = []
 
         installed = os.path.exists(self.hf_path)
+        requirements_filename = os.path.abspath(os.path.realpath(os.path.join(self.root_path, 'requirements.txt')))
+        has_requirement = os.path.exists(requirements_filename)
 
         if isinstance(self.gradio_metas, tuple):
             results.append(build_html(title=self.title, installed=installed, url=self.gradio_metas[1]))
         else:
             results.append(build_html(title=self.title, installed=installed, url=None))
 
-        results.append(gr.update(interactive=not self.is_running and not installed))
+        results.append(gr.update(interactive=not self.is_running and not (installed and not has_requirement), value=("Reinstall" if (installed and has_requirement) else "Install")))
         results.append(gr.update(interactive=not self.is_running and installed))
         results.append(gr.update(interactive=installed and not self.is_running))
         results.append(gr.update(interactive=installed and self.is_running))
         return results
 
     def install(self):
+        installed = os.path.exists(self.hf_path)
         os.makedirs(self.hf_path, exist_ok=True)
 
-        if self.repo_id is not None:
+        if self.repo_id is not None and not installed:
             downloaded = snapshot_download(
                 repo_id=self.repo_id,
                 repo_type=self.repo_type,


### PR DESCRIPTION
### Context

If you *"mess up"* your Python virtual environment *(`venv`)*, such as installing Extensions that cause package version conflicts, one of the easiest way to solve this is to delete the `venv` folder and let the Webui reinstall everything again. However, currently there is no way to reinstall specifically the requirements for Spaces, other than completely uninstall and install again, which includes wiping and cloning the Space repo again as well. And certain repo is quite large in size *(**eg.** The repo for `IDM-VTON` is close to 1 GB)*, so this approach might not be ideal.

### PR

- Make the `Install` button show as `Reinstall` if the Space is installed and a `requiremenets.txt` file exists; otherwise behave like how it currently works. 
- Set `force_download` to `False` so that it will not clone the entire repo again if the files already present