### PR TITLE
autoset width and height

### DIFF
--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -191,7 +191,9 @@ def img2img_function(id_task: str, request: gr.Request, mode: int, prompt: str, 
         assert image, "Can't scale by because no image is selected"
 
         width = int(image.width * scale_by)
+        width -= width % 8
         height = int(image.height * scale_by)
+        height -= height % 8
 
     assert 0. <= denoising_strength <= 1., 'can only work with strength in [0.0, 1.0]'
 

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -229,6 +229,8 @@ options_templates.update(options_section(('img2img', "img2img", "sd"), {
     "return_mask_composite": OptionInfo(False, "For inpainting, include masked composite in results for web"),
     "img2img_batch_show_results_limit": OptionInfo(32, "Show the first N batch img2img results in UI", gr.Slider, {"minimum": -1, "maximum": 1000, "step": 1}).info('0: disable, -1: show all images. Too many images can cause lag'),
     "overlay_inpaint": OptionInfo(True, "Overlay original for inpaint").info("when inpainting, overlay the original image over the areas that weren't inpainted."),
+    "img2img_autosize": OptionInfo(False, "After loading into Img2img, automatically update Width and Height"),
+
 }))
 
 options_templates.update(options_section(('optimizations', "Optimizations", "sd"), {

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -665,7 +665,7 @@ def create_ui():
 
                                     img_sources = [init_img.background, sketch.background, init_img_with_mask.background, inpaint_color_sketch.background, init_img_inpaint]
                                     for i in img_sources:
-                                        i.change(fn=updateWH, inputs=[i, width, height], outputs=[width, height])
+                                        i.change(fn=updateWH, inputs=[i, width, height], outputs=[width, height], show_progress='hidden')
                                         i.change(**on_change_args)
 
                             tab_scale_to.select(fn=lambda: 0, inputs=[], outputs=[selected_scale_tab])

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -112,6 +112,9 @@ def resize_from_to_html(width, height, scale_by):
     if not target_width or not target_height:
         return "no image selected"
 
+    target_width -= target_width % 8        #   note: hardcoded latent size 8
+    target_height -= target_height % 8
+
     return f"resize: from <span class='resolution'>{width}x{height}</span> to <span class='resolution'>{target_width}x{target_height}</span>"
 
 
@@ -636,7 +639,7 @@ def create_ui():
                                                 detect_image_size_btn = ToolButton(value=detect_image_size_symbol, elem_id="img2img_detect_image_size_btn", tooltip="Auto detect size from img2img")
 
                                     with gr.Tab(label="Resize by", id="by", elem_id="img2img_tab_resize_by") as tab_scale_by:
-                                        scale_by = gr.Slider(minimum=0.05, maximum=4.0, step=0.05, label="Scale", value=1.0, elem_id="img2img_scale")
+                                        scale_by = gr.Slider(minimum=0.05, maximum=4.0, step=0.01, label="Scale", value=1.0, elem_id="img2img_scale")
 
                                         with FormRow():
                                             scale_by_html = FormHTML(resize_from_to_html(0, 0, 0.0), elem_id="img2img_scale_resolution_preview")
@@ -651,8 +654,19 @@ def create_ui():
                                         show_progress=False,
                                     )
 
-                                    scale_by.release(**on_change_args)
+                                    scale_by.change(**on_change_args)
                                     button_update_resize_to.click(**on_change_args)
+
+                                    def updateWH (img, w, h):
+                                        if img and shared.opts.img2img_autosize == True:
+                                            return img.size[0], img.size[1]
+                                        else:
+                                            return w, h
+
+                                    img_sources = [init_img.background, sketch.background, init_img_with_mask.background, inpaint_color_sketch.background, init_img_inpaint]
+                                    for i in img_sources:
+                                        i.change(fn=updateWH, inputs=[i, width, height], outputs=[width, height])
+                                        i.change(**on_change_args)
 
                             tab_scale_to.select(fn=lambda: 0, inputs=[], outputs=[selected_scale_tab])
                             tab_scale_by.select(fn=lambda: 1, inputs=[], outputs=[selected_scale_tab])


### PR DESCRIPTION
* When loading into img2img, added an option to automatically set Width and Height from image (Settings -> img2img ->After loading into Img2img, automatically update Width and Height).
* fixed **Resize by** *Scale* display, now correctly rounded to multiple of 8
* That display now updates on change, instead of on release, so it updates as the slider is dragged and when an image is loaded (if option enabled)
* Also fixed new width/height calculation inside img2img function, same fix, (affects infotext)