### PR TITLE
partial revert to fix compatible issue

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -113,6 +113,17 @@ function get_img2img_tab_index() {
 function create_submit_args(args) {
     var res = Array.from(args);
 
+    // As it is currently, txt2img and img2img send back the previous output args (txt2img_gallery, generation_info, html_info) whenever you generate a new image.
+    // This can lead to uploading a huge gallery of previously generated images, which leads to an unnecessary delay between submitting and beginning to generate.
+    // I don't know why gradio is sending outputs along with inputs, but we can prevent sending the image gallery here, which seems to be an issue for some.
+
+    // If gradio at some point stops sending outputs, this may break something
+    if (Array.isArray(res[res.length - 4])) {
+        //res[res.length - 4] = null;
+        // simply drop output args
+        res = res.slice(0, res.length - 4);
+    }
+
     return res;
 }
 
@@ -136,7 +147,7 @@ function showRestoreProgressButton(tabname, show) {
     button.style.setProperty('display', show ? 'flex' : 'none', 'important');
 }
 
-function submit(args) {
+function submit() {
     showSubmitButtons('txt2img', false);
 
     var id = randomId();
@@ -148,22 +159,22 @@ function submit(args) {
         showRestoreProgressButton('txt2img', false);
     });
 
-    var res = create_submit_args(args);
+    var res = create_submit_args(arguments);
 
     res[0] = id;
 
     return res;
 }
 
-function submit_txt2img_upscale(args) {
-    var res = submit(args);
+function submit_txt2img_upscale() {
+    var res = submit(...arguments);
 
     res[2] = selected_gallery_index();
 
     return res;
 }
 
-function submit_img2img(args) {
+function submit_img2img() {
     showSubmitButtons('img2img', false);
 
     var id = randomId();
@@ -175,14 +186,14 @@ function submit_img2img(args) {
         showRestoreProgressButton('img2img', false);
     });
 
-    var res = create_submit_args(args);
+    var res = create_submit_args(arguments);
 
     res[0] = id;
 
     return res;
 }
 
-function submit_extras(args) {
+function submit_extras() {
     showSubmitButtons('extras', false);
 
     var id = randomId();
@@ -191,7 +202,7 @@ function submit_extras(args) {
         showSubmitButtons('extras', true);
     });
 
-    var res = create_submit_args(args);
+    var res = create_submit_args(arguments);
 
     res[0] = id;
 

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -122,6 +122,10 @@ function create_submit_args(args) {
         //res[res.length - 4] = null;
         // simply drop output args
         res = res.slice(0, res.length - 4);
+    } else if (Array.isArray(res[res.length - 3])) {
+        // for submit_extras()
+        //res[res.length - 3] = null;
+        res = res.slice(0, res.length - 3);
     }
 
     return res;

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -437,7 +437,7 @@ def create_ui():
 
             txt2img_args = dict(
                 fn=wrap_gradio_gpu_call(modules.txt2img.txt2img, extra_outputs=[None, '', '']),
-                js=f"(...args) => {{ return submit(args.slice(0, {len(txt2img_inputs)})); }}",
+                _js="submit",
                 inputs=txt2img_inputs,
                 outputs=txt2img_outputs,
                 show_progress=False,
@@ -449,7 +449,7 @@ def create_ui():
             txt2img_upscale_inputs = txt2img_inputs[0:1] + [output_panel.gallery, dummy_component_number, output_panel.generation_info] + txt2img_inputs[1:]
             output_panel.button_upscale.click(
                 fn=wrap_gradio_gpu_call(modules.txt2img.txt2img_upscale, extra_outputs=[None, '', '']),
-                js=f"(...args) => {{ return submit_txt2img_upscale(args.slice(0, {len(txt2img_upscale_inputs)})); }}",
+                _js="submit_txt2img_upscale",
                 inputs=txt2img_upscale_inputs,
                 outputs=txt2img_outputs,
                 show_progress=False,
@@ -787,7 +787,7 @@ def create_ui():
 
             img2img_args = dict(
                 fn=wrap_gradio_gpu_call(modules.img2img.img2img, extra_outputs=[None, '', '']),
-                js=f"(...args) => {{ return submit_img2img(args.slice(0, {len(submit_img2img_inputs)})); }}",
+                _js="submit_img2img",
                 inputs=submit_img2img_inputs,
                 outputs=[
                     output_panel.gallery,

--- a/modules/ui_postprocessing.py
+++ b/modules/ui_postprocessing.py
@@ -49,7 +49,7 @@ def create_ui():
 
     submit.click(
         fn=call_queue.wrap_gradio_gpu_call(postprocessing.run_postprocessing_webui, extra_outputs=[None, '']),
-        js=f"(...args) => {{ return submit_extras(args.slice(0, {len(submit_click_inputs)})); }}",
+        _js=f"submit_extras",
         inputs=submit_click_inputs,
         outputs=[
             output_panel.gallery,


### PR DESCRIPTION
* fix `submit()`, `submit_*()`, `create_submit_args()`
* ~~add `console.warn = function(){};` to ignore bunch of warnings~~ extracted to another PR.

these `submit*()` are used several extensions by means of hook or direct call.
this fix revert some part of gradio 4 fix to make it more compatible with A1111.
for example, uddetailer use `submit.apply()` call directly.