### PR TITLE
workaround fix to suppress console.warn

### DIFF
--- a/javascript/gradio.js
+++ b/javascript/gradio.js
@@ -5,3 +5,7 @@ Object.defineProperty(Array.prototype, 'toLowerCase', {
         return this;
     }
 });
+
+// disable console.warn
+let save_console_warn = console.warn
+console.warn = function(){};


### PR DESCRIPTION
without this fix you may get too much noisy warnings in your chrome debug console. it's not forge's fault. its a gradio4 bug.

![image](https://github.com/user-attachments/assets/093f8446-9c43-4d62-8b7b-b595a6ed6040)
