### PR TITLE
More UI settings

### DIFF
--- a/modules/processing_scripts/sampler.py
+++ b/modules/processing_scripts/sampler.py
@@ -37,6 +37,25 @@ class ScriptSampler(scripts.ScriptBuiltinUI):
             PasteField(self.scheduler, sd_samplers.get_scheduler_from_infotext, api="scheduler"),
         ]
 
+        shared.options_templates.update(shared.options_section(('ui_sd', "UI defaults 'sd'", "ui"), {
+            "sd_t2i_sampler":     shared.OptionInfo('Euler a',      "txt2img sampler",      gr.Dropdown, {"choices": sampler_names}),
+            "sd_t2i_scheduler":   shared.OptionInfo('Automatic',    "txt2img scheduler",    gr.Dropdown, {"choices": scheduler_names}),
+            "sd_i2i_sampler":     shared.OptionInfo('Euler a',      "img2img sampler",      gr.Dropdown, {"choices": sampler_names}),
+            "sd_i2i_scheduler":   shared.OptionInfo('Automatic',    "img2img scheduler",    gr.Dropdown, {"choices": scheduler_names}),
+        }))
+        shared.options_templates.update(shared.options_section(('ui_xl', "UI defaults 'xl'", "ui"), {
+            "xl_t2i_sampler":     shared.OptionInfo('DPM++ 2M SDE', "txt2img sampler",      gr.Dropdown, {"choices": sampler_names}),
+            "xl_t2i_scheduler":   shared.OptionInfo('Karras',       "txt2img scheduler",    gr.Dropdown, {"choices": scheduler_names}),
+            "xl_i2i_sampler":     shared.OptionInfo('DPM++ 2M SDE', "img2img sampler",      gr.Dropdown, {"choices": sampler_names}),
+            "xl_i2i_scheduler":   shared.OptionInfo('Karras',       "img2img scheduler",    gr.Dropdown, {"choices": scheduler_names}),
+        }))
+        shared.options_templates.update(shared.options_section(('ui_flux', "UI defaults 'flux'", "ui"), {
+            "flux_t2i_sampler":   shared.OptionInfo('Euler',        "txt2img sampler",      gr.Dropdown, {"choices": sampler_names}),
+            "flux_t2i_scheduler": shared.OptionInfo('Simple',       "txt2img scheduler",    gr.Dropdown, {"choices": scheduler_names}),
+            "flux_i2i_sampler":   shared.OptionInfo('Euler',        "img2img sampler",      gr.Dropdown, {"choices": sampler_names}),
+            "flux_i2i_scheduler": shared.OptionInfo('Simple',       "img2img scheduler",    gr.Dropdown, {"choices": scheduler_names}),
+        }))
+
         return self.steps, self.sampler_name, self.scheduler
 
     def setup(self, p, steps, sampler_name, scheduler):

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -321,10 +321,10 @@ def on_preset_change(preset=None):
             gr.update(value=getattr(shared.opts, "sd_i2i_cfg", 7)),                     # ui_img2img_cfg
             gr.update(visible=False, value=3.5),                                        # ui_txt2img_distilled_cfg
             gr.update(visible=False, value=3.5),                                        # ui_img2img_distilled_cfg
-            gr.update(value='Euler a'),                                                 # ui_txt2img_sampler
-            gr.update(value='Euler a'),                                                 # ui_img2img_sampler
-            gr.update(value='Automatic'),                                               # ui_txt2img_scheduler
-            gr.update(value='Automatic'),                                               # ui_img2img_scheduler
+            gr.update(value=getattr(shared.opts, "sd_t2i_sampler", 'Euler a')),         # ui_txt2img_sampler
+            gr.update(value=getattr(shared.opts, "sd_i2i_sampler", 'Euler a')),         # ui_txt2img_sampler
+            gr.update(value=getattr(shared.opts, "sd_t2i_scheduler", 'Automatic')),     # ui_txt2img_scheduler
+            gr.update(value=getattr(shared.opts, "sd_i2i_scheduler", 'Automatic')),     # ui_txt2img_scheduler
             gr.update(visible=True, value=getattr(shared.opts, "sd_t2i_hr_cfg", 7.0)),  # ui_txt2img_hr_cfg
             gr.update(visible=False, value=3.5),                                        # ui_txt2img_hr_distilled_cfg
         ]
@@ -336,7 +336,7 @@ def on_preset_change(preset=None):
             gr.update(visible=True, value='Automatic'),                                 # ui_forge_unet_storage_dtype_options
             gr.update(visible=False, value='Queue'),                                    # ui_forge_async_loading
             gr.update(visible=False, value='CPU'),                                      # ui_forge_pin_shared_memory
-            gr.update(visible=True, value=total_vram - 1024),                           # ui_forge_inference_memory
+            gr.update(visible=True, value=getattr(shared.opts, "xl_GPU_MB", total_vram - 1024)),   # ui_forge_inference_memory
             gr.update(value=getattr(shared.opts, "xl_t2i_width", 896)),                 # ui_txt2img_width
             gr.update(value=getattr(shared.opts, "xl_i2i_width", 1024)),                # ui_img2img_width
             gr.update(value=getattr(shared.opts, "xl_t2i_height", 1152)),               # ui_txt2img_height
@@ -345,10 +345,10 @@ def on_preset_change(preset=None):
             gr.update(value=getattr(shared.opts, "xl_i2i_cfg", 5)),                     # ui_img2img_cfg
             gr.update(visible=False, value=3.5),                                        # ui_txt2img_distilled_cfg
             gr.update(visible=False, value=3.5),                                        # ui_img2img_distilled_cfg
-            gr.update(value='DPM++ 2M SDE'),                                            # ui_txt2img_sampler
-            gr.update(value='DPM++ 2M SDE'),                                            # ui_img2img_sampler
-            gr.update(value='Karras'),                                                  # ui_txt2img_scheduler
-            gr.update(value='Karras'),                                                  # ui_img2img_scheduler
+            gr.update(value=getattr(shared.opts, "xl_t2i_sampler", 'Euler a')),         # ui_txt2img_sampler
+            gr.update(value=getattr(shared.opts, "xl_i2i_sampler", 'Euler a')),         # ui_txt2img_sampler
+            gr.update(value=getattr(shared.opts, "xl_t2i_scheduler", 'Automatic')),     # ui_txt2img_scheduler
+            gr.update(value=getattr(shared.opts, "xl_i2i_scheduler", 'Automatic')),     # ui_txt2img_scheduler
             gr.update(visible=True, value=getattr(shared.opts, "xl_t2i_hr_cfg", 5.0)),  # ui_txt2img_hr_cfg
             gr.update(visible=False, value=3.5),                                        # ui_txt2img_hr_distilled_cfg
         ]
@@ -360,7 +360,7 @@ def on_preset_change(preset=None):
             gr.update(visible=True, value='Automatic'),                                 # ui_forge_unet_storage_dtype_options
             gr.update(visible=True, value='Queue'),                                     # ui_forge_async_loading
             gr.update(visible=True, value='CPU'),                                       # ui_forge_pin_shared_memory
-            gr.update(visible=True, value=total_vram - 1024),                           # ui_forge_inference_memory
+            gr.update(visible=True, value=getattr(shared.opts, "flux_GPU_MB", total_vram - 1024)), # ui_forge_inference_memory
             gr.update(value=getattr(shared.opts, "flux_t2i_width", 896)),               # ui_txt2img_width
             gr.update(value=getattr(shared.opts, "flux_i2i_width", 1024)),              # ui_img2img_width
             gr.update(value=getattr(shared.opts, "flux_t2i_height", 1152)),             # ui_txt2img_height
@@ -369,10 +369,10 @@ def on_preset_change(preset=None):
             gr.update(value=getattr(shared.opts, "flux_i2i_cfg", 1)),                   # ui_img2img_cfg
             gr.update(visible=True, value=getattr(shared.opts, "flux_t2i_d_cfg", 3.5)), # ui_txt2img_distilled_cfg
             gr.update(visible=True, value=getattr(shared.opts, "flux_i2i_d_cfg", 3.5)), # ui_img2img_distilled_cfg
-            gr.update(value='Euler'),                                                   # ui_txt2img_sampler
-            gr.update(value='Euler'),                                                   # ui_img2img_sampler
-            gr.update(value='Simple'),                                                  # ui_txt2img_scheduler
-            gr.update(value='Simple'),                                                  # ui_img2img_scheduler
+            gr.update(value=getattr(shared.opts, "flux_t2i_sampler", 'Euler')),         # ui_txt2img_sampler
+            gr.update(value=getattr(shared.opts, "flux_i2i_sampler", 'Euler')),         # ui_txt2img_sampler
+            gr.update(value=getattr(shared.opts, "flux_t2i_scheduler", 'Simple')),      # ui_txt2img_scheduler
+            gr.update(value=getattr(shared.opts, "flux_i2i_scheduler", 'Simple')),      # ui_txt2img_scheduler
             gr.update(visible=True, value=getattr(shared.opts, "flux_t2i_hr_cfg", 1.0)),    # ui_txt2img_hr_cfg
             gr.update(visible=True, value=getattr(shared.opts, "flux_t2i_hr_d_cfg", 3.5)),  # ui_txt2img_hr_distilled_cfg
         ]
@@ -420,6 +420,7 @@ shared.options_templates.update(shared.options_section(('ui_xl', "UI defaults 'x
     "xl_i2i_width":  shared.OptionInfo(1024, "img2img width",      gr.Slider, {"minimum": 64, "maximum": 2048, "step": 8}),
     "xl_i2i_height": shared.OptionInfo(1024, "img2img height",     gr.Slider, {"minimum": 64, "maximum": 2048, "step": 8}),
     "xl_i2i_cfg":    shared.OptionInfo(5,    "img2img CFG",        gr.Slider, {"minimum": 1,  "maximum": 30,   "step": 0.1}),
+    "xl_GPU_MB":     shared.OptionInfo(total_vram - 1024, "GPU Weights (MB)", gr.Slider, {"minimum": 0,  "maximum": total_vram,   "step": 1}),
 }))
 shared.options_templates.update(shared.options_section(('ui_flux', "UI defaults 'flux'", "ui"), {
     "flux_t2i_width":    shared.OptionInfo(896,  "txt2img width",                gr.Slider, {"minimum": 64, "maximum": 2048, "step": 8}),
@@ -432,4 +433,5 @@ shared.options_templates.update(shared.options_section(('ui_flux', "UI defaults 
     "flux_i2i_height":   shared.OptionInfo(1024, "img2img height",               gr.Slider, {"minimum": 64, "maximum": 2048, "step": 8}),
     "flux_i2i_cfg":      shared.OptionInfo(1,    "img2img CFG",                  gr.Slider, {"minimum": 1,  "maximum": 30,   "step": 0.1}),
     "flux_i2i_d_cfg":    shared.OptionInfo(3.5,  "img2img Distilled CFG",        gr.Slider, {"minimum": 0,  "maximum": 30,   "step": 0.1}),
+    "flux_GPU_MB":       shared.OptionInfo(total_vram - 1024, "GPU Weights (MB)",gr.Slider, {"minimum": 0,  "maximum": total_vram,   "step": 1}),
 }))

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -112,7 +112,7 @@ def make_checkpoint_manager_ui():
 
     mem_comps = [ui_forge_inference_memory, ui_forge_async_loading, ui_forge_pin_shared_memory]
 
-    ui_forge_inference_memory.release(refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)
+    ui_forge_inference_memory.change(refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)
     ui_forge_async_loading.change(refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)
     ui_forge_pin_shared_memory.change(refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)
     Context.root_block.load(refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -322,9 +322,9 @@ def on_preset_change(preset=None):
             gr.update(visible=False, value=3.5),                                        # ui_txt2img_distilled_cfg
             gr.update(visible=False, value=3.5),                                        # ui_img2img_distilled_cfg
             gr.update(value=getattr(shared.opts, "sd_t2i_sampler", 'Euler a')),         # ui_txt2img_sampler
-            gr.update(value=getattr(shared.opts, "sd_i2i_sampler", 'Euler a')),         # ui_txt2img_sampler
+            gr.update(value=getattr(shared.opts, "sd_i2i_sampler", 'Euler a')),         # ui_img2img_sampler
             gr.update(value=getattr(shared.opts, "sd_t2i_scheduler", 'Automatic')),     # ui_txt2img_scheduler
-            gr.update(value=getattr(shared.opts, "sd_i2i_scheduler", 'Automatic')),     # ui_txt2img_scheduler
+            gr.update(value=getattr(shared.opts, "sd_i2i_scheduler", 'Automatic')),     # ui_img2img_scheduler
             gr.update(visible=True, value=getattr(shared.opts, "sd_t2i_hr_cfg", 7.0)),  # ui_txt2img_hr_cfg
             gr.update(visible=False, value=3.5),                                        # ui_txt2img_hr_distilled_cfg
         ]
@@ -346,9 +346,9 @@ def on_preset_change(preset=None):
             gr.update(visible=False, value=3.5),                                        # ui_txt2img_distilled_cfg
             gr.update(visible=False, value=3.5),                                        # ui_img2img_distilled_cfg
             gr.update(value=getattr(shared.opts, "xl_t2i_sampler", 'Euler a')),         # ui_txt2img_sampler
-            gr.update(value=getattr(shared.opts, "xl_i2i_sampler", 'Euler a')),         # ui_txt2img_sampler
+            gr.update(value=getattr(shared.opts, "xl_i2i_sampler", 'Euler a')),         # ui_img2img_sampler
             gr.update(value=getattr(shared.opts, "xl_t2i_scheduler", 'Automatic')),     # ui_txt2img_scheduler
-            gr.update(value=getattr(shared.opts, "xl_i2i_scheduler", 'Automatic')),     # ui_txt2img_scheduler
+            gr.update(value=getattr(shared.opts, "xl_i2i_scheduler", 'Automatic')),     # ui_img2img_scheduler
             gr.update(visible=True, value=getattr(shared.opts, "xl_t2i_hr_cfg", 5.0)),  # ui_txt2img_hr_cfg
             gr.update(visible=False, value=3.5),                                        # ui_txt2img_hr_distilled_cfg
         ]
@@ -370,9 +370,9 @@ def on_preset_change(preset=None):
             gr.update(visible=True, value=getattr(shared.opts, "flux_t2i_d_cfg", 3.5)), # ui_txt2img_distilled_cfg
             gr.update(visible=True, value=getattr(shared.opts, "flux_i2i_d_cfg", 3.5)), # ui_img2img_distilled_cfg
             gr.update(value=getattr(shared.opts, "flux_t2i_sampler", 'Euler')),         # ui_txt2img_sampler
-            gr.update(value=getattr(shared.opts, "flux_i2i_sampler", 'Euler')),         # ui_txt2img_sampler
+            gr.update(value=getattr(shared.opts, "flux_i2i_sampler", 'Euler')),         # ui_img2img_sampler
             gr.update(value=getattr(shared.opts, "flux_t2i_scheduler", 'Simple')),      # ui_txt2img_scheduler
-            gr.update(value=getattr(shared.opts, "flux_i2i_scheduler", 'Simple')),      # ui_txt2img_scheduler
+            gr.update(value=getattr(shared.opts, "flux_i2i_scheduler", 'Simple')),      # ui_img2img_scheduler
             gr.update(visible=True, value=getattr(shared.opts, "flux_t2i_hr_cfg", 1.0)),    # ui_txt2img_hr_cfg
             gr.update(visible=True, value=getattr(shared.opts, "flux_t2i_hr_d_cfg", 3.5)),  # ui_txt2img_hr_distilled_cfg
         ]


### PR DESCRIPTION
adds options for user-set defaults for **Sampler** and **Scheduler** to UI settings *sd*, *xl*, *flux*;
adds options for user-set defaults for **GPU Weights** to UI settings *xl*, *flux*;
necessitates change to *.input* event listener instead of *.release* for `ui_forge_inference_memory`, which may be more correct anyway.