### PR TITLE
Fix for use original name with batch img2img

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -674,9 +674,9 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
         if short_filename or seed is None:
             file_decoration = ""
         elif opts.save_to_dirs:
-            file_decoration = opts.samples_filename_pattern or "[seed]"
+            file_decoration = opts.samples_filename_pattern or p.override_settings.get("samples_filename_pattern") or "[seed]"
         else:
-            file_decoration = opts.samples_filename_pattern or "[seed]-[prompt_spaces]"
+            file_decoration = opts.samples_filename_pattern or p.override_settings.get("samples_filename_pattern") or "[seed]-[prompt_spaces]"
 
         file_decoration = namegen.apply(file_decoration) + suffix
 

--- a/modules/img2img.py
+++ b/modules/img2img.py
@@ -122,16 +122,14 @@ def process_batch(p, input, output_dir, inpaint_mask_dir, args, to_scale=False, 
         if output_dir:
             p.outpath_samples = output_dir
             p.override_settings['save_to_dirs'] = False
-            p.override_settings['save_images_replace_action'] = "Add number suffix"
-            if p.n_iter > 1 or p.batch_size > 1:
-                p.override_settings['samples_filename_pattern'] = f'{image_path.stem}-[generation_number]'
-            else:
-                p.override_settings['samples_filename_pattern'] = f'{image_path.stem}'
+
+        if opts.img2img_batch_use_original_name:
+            filename_pattern = f'{image_path.stem}-[generation_number]' if p.n_iter > 1 or p.batch_size > 1 else f'{image_path.stem}'
+            p.override_settings['samples_filename_pattern'] = filename_pattern
 
         proc = modules.scripts.scripts_img2img.run(p, *args)
 
         if proc is None:
-            p.override_settings.pop('save_images_replace_action', None)
             proc = process_images(p)
 
         if not discard_further_results and proc:

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -230,7 +230,7 @@ options_templates.update(options_section(('img2img', "img2img", "sd"), {
     "img2img_batch_show_results_limit": OptionInfo(32, "Show the first N batch img2img results in UI", gr.Slider, {"minimum": -1, "maximum": 1000, "step": 1}).info('0: disable, -1: show all images. Too many images can cause lag'),
     "overlay_inpaint": OptionInfo(True, "Overlay original for inpaint").info("when inpainting, overlay the original image over the areas that weren't inpainted."),
     "img2img_autosize": OptionInfo(False, "After loading into Img2img, automatically update Width and Height"),
-
+    "img2img_batch_use_original_name": OptionInfo(False, "Save using original filename in img2img batch. Applies to 'Upload' and 'From directory' tabs.").info("Warning: overwriting is possible, based on Settings > Saving images/grids > Saving the image to an existing file.")
 }))
 
 options_templates.update(options_section(('optimizations', "Optimizations", "sd"), {


### PR DESCRIPTION
Hello. My friends use this tools and asked me to look why when use batch in img2img original name can't be save.

I'm found a bug when in **images.py** don't apply _samples_filename_pattern_ from img2img.py because pattern was write into **override_settings** but read only from **options** (**opts**). Fixed it.

For upload tab original filename never saved because **output_dir** forced set to empty. It's may be justified because we will override already existing files in some cases. I'm added new checkbox to upload tab for use original filename if it's really necessary.