### PR TITLE
Apply memory changes via API

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -687,12 +687,22 @@ class Api:
         checkpoint_name = req.get("sd_model_checkpoint", None)
         if checkpoint_name is not None and checkpoint_name not in sd_models.checkpoint_aliases:
             raise RuntimeError(f"model {checkpoint_name!r} not found")
+        
+        refresh_memory = False
+        memory_keys = ['forge_inference_memory', 'forge_async_loading', 'forge_pin_shared_memory']
 
         for k, v in req.items():
             shared.opts.set(k, v, is_api=True)
+            if k in memory_keys:
+                refresh_memory = True
 
         main_entry.checkpoint_change(checkpoint_name)
         # shared.opts.save(shared.config_filename) --- applied in checkpoint_change()
+
+        if refresh_memory:
+            model_memory = main_entry.total_vram - shared.opts.forge_inference_memory
+            main_entry.refresh_memory_management_settings(model_memory, shared.opts.forge_async_loading, shared.opts.forge_pin_shared_memory)
+
         return
 
     def get_cmd_flags(self):


### PR DESCRIPTION
Actually apply memory related changes posted to `/sdapi/v1/options`:
- 'forge_inference_memory'
- 'forge_async_loading'
- 'forge_pin_shared_memory'

<img width="671" alt="image" src="https://github.com/user-attachments/assets/bd51e507-21bc-4336-895b-0c2759d83b4d">

---

Known bug:
The values will reset if refreshing the UI.
I tried updating UI values in tandem, but can't overcome "can't change Blocks outside gradio context".