### PR TITLE
fix Extra networks tree show / edit

### DIFF
--- a/html/extra-networks-tree-button.html
+++ b/html/extra-networks-tree-button.html
@@ -2,6 +2,7 @@
 <div class="tree-list-content {subclass}"
     type="button"
     onclick="extraNetworksTreeOnClick(event, '{tabname}', '{extra_networks_tabname}');{onclick_extra}"
+    data-name="{action_list_item_label}" 
     data-path="{data_path}"
     data-hash="{data_hash}"
 >

--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -682,6 +682,9 @@ function extraNetworksEditUserMetadata(event, tabname, extraPage) {
     }
 
     var cardName = event.target.parentElement.parentElement.getAttribute("data-name");
+    if (cardName == null) { // from tree
+        cardName = event.target.parentElement.parentElement.parentElement.getAttribute("data-name");
+    }
     editor.nameTextarea.value = cardName;
     updateInput(editor.nameTextarea);
 

--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -655,6 +655,9 @@ function extraNetworksRequestMetadata(event, extraPage) {
     };
 
     var cardName = event.target.parentElement.parentElement.getAttribute("data-name");
+    if (cardName == null) { // from tree
+        cardName = event.target.parentElement.parentElement.parentElement.getAttribute("data-name");
+    }
 
     requestGet("./sd_extra_networks/metadata", {page: extraPage, item: cardName}, function(data) {
         if (data && data.metadata) {


### PR DESCRIPTION
Fix 'Show internal metadata' and 'Edit metadata' buttons when used from treeview. Issue seems like an oversight from an upstream change to handle filenames with an apostrophe.
#1244