### PR TITLE
(T5) pad chunks to length of longest chunk

### DIFF
--- a/backend/text_processing/t5_engine.py
+++ b/backend/text_processing/t5_engine.py
@@ -117,9 +117,21 @@ class T5TextProcessingEngine:
             else:
                 chunks, token_count = self.tokenize_line(line)
                 line_z_values = []
+
+                #   pad all chunks to length of longest chunk
+                max_tokens = 0
+                for chunk in chunks:
+                    max_tokens = max (len(chunk.tokens), max_tokens)
+
                 for chunk in chunks:
                     tokens = chunk.tokens
                     multipliers = chunk.multipliers
+                    
+                    remaining_count = max_tokens - len(tokens)
+                    if remaining_count > 0:
+                        tokens += [self.id_pad] * remaining_count
+                        multipliers += [1.0] * remaining_count
+
                     z = self.process_tokens([tokens], [multipliers])[0]
                     line_z_values.append(z)
                 cache[line] = line_z_values


### PR DESCRIPTION
When the prompt is chunked using the BREAK keyword, chunks will be padded to the minimum size of 256 tokens - but chunks can be longer. torch.stack then fails if all chunks are not the same size, so find the longest and pad all to match.
I assume that a list of 2+ prompts could hit the same issue, but did all my testing with BREAK.
#1988 (doesn't quite ID correctly, long prompts had no problem in my tests, but did expose the issue)

alternative approach: truncate, line 52 same file:
 `        tokenized = self.tokenizer(texts, max_length=255, truncation=True, add_special_tokens=False)["input_ids"]`