### PR TITLE
API Improvements: Modules Change AND Restore override_settings

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -692,10 +692,13 @@ class Api:
         memory_keys = ['forge_inference_memory', 'forge_async_loading', 'forge_pin_shared_memory']
 
         for k, v in req.items():
+            # options for memory/modules are set in their dedicated functions
             if k in memory_keys:
-                memory_changes[k] = v
+                mem_key = k[len('forge_'):] # remove 'forge_' prefix
+                memory_changes[mem_key] = v
             elif k == 'forge_additional_modules':
                 main_entry.modules_change(v, refresh_params=False) # refresh_model_loading_parameters() --- applied in checkpoint_change()
+            # set all other options
             else:
                 shared.opts.set(k, v, is_api=True)
 

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -692,9 +692,12 @@ class Api:
         memory_keys = ['forge_inference_memory', 'forge_async_loading', 'forge_pin_shared_memory']
 
         for k, v in req.items():
-            shared.opts.set(k, v, is_api=True)
             if k in memory_keys:
                 refresh_memory = True
+            if k == 'forge_additional_modules':
+                main_entry.modules_change(v, refresh_params=False)
+            else:
+                shared.opts.set(k, v, is_api=True)
 
         main_entry.checkpoint_change(checkpoint_name)
         # shared.opts.save(shared.config_filename) --- applied in checkpoint_change()

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -688,23 +688,22 @@ class Api:
         if checkpoint_name is not None and checkpoint_name not in sd_models.checkpoint_aliases:
             raise RuntimeError(f"model {checkpoint_name!r} not found")
         
-        refresh_memory = False
+        memory_changes = {}
         memory_keys = ['forge_inference_memory', 'forge_async_loading', 'forge_pin_shared_memory']
 
         for k, v in req.items():
             if k in memory_keys:
-                refresh_memory = True
-            if k == 'forge_additional_modules':
-                main_entry.modules_change(v, refresh_params=False)
+                memory_changes[k] = v
+            elif k == 'forge_additional_modules':
+                main_entry.modules_change(v, refresh_params=False) # refresh_model_loading_parameters() --- applied in checkpoint_change()
             else:
                 shared.opts.set(k, v, is_api=True)
 
         main_entry.checkpoint_change(checkpoint_name)
         # shared.opts.save(shared.config_filename) --- applied in checkpoint_change()
 
-        if refresh_memory:
-            model_memory = main_entry.total_vram - shared.opts.forge_inference_memory
-            main_entry.refresh_memory_management_settings(model_memory, shared.opts.forge_async_loading, shared.opts.forge_pin_shared_memory)
+        if memory_changes:
+            main_entry.refresh_memory_management_settings(**memory_changes)
 
         return
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -32,6 +32,7 @@ from einops import repeat, rearrange
 from blendmodes.blend import blendLayers, BlendType
 from modules.sd_models import apply_token_merging, forge_model_reload
 from modules_forge.utils import apply_circular_forge
+from modules_forge import main_entry
 from backend import memory_management
 
 
@@ -810,11 +811,54 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
     if p.scripts is not None:
         p.scripts.before_process(p)
 
-    # backwards compatibility, fix sampler and scheduler if invalid
-    sd_samplers.fix_p_invalid_sampler_and_scheduler(p)
+    stored_opts = {k: opts.data[k] if k in opts.data else opts.get_default(k) for k in p.override_settings.keys() if k in opts.data}
 
-    with profiling.Profiler():
-        res = process_images_inner(p)
+    try:
+        # if no checkpoint override or the override checkpoint can't be found, remove override entry and load opts checkpoint
+        # and if after running refiner, the refiner model is not unloaded - webui swaps back to main model here, if model over is present it will be reloaded afterwards
+        if sd_models.checkpoint_aliases.get(p.override_settings.get('sd_model_checkpoint')) is None:
+            p.override_settings.pop('sd_model_checkpoint', None)
+
+        refresh_memory = False
+        memory_keys = ['forge_inference_memory', 'forge_async_loading', 'forge_pin_shared_memory']
+
+        for k, v in p.override_settings.items():
+            if k in memory_keys:
+                refresh_memory = True
+            if k == 'forge_additional_modules':
+                main_entry.modules_change(v, refresh_params=False)
+            elif k == 'sd_model_checkpoint':
+                main_entry.checkpoint_change(v)
+            else:
+                opts.set(k, v, is_api=True, run_callbacks=False)
+
+        if refresh_memory:
+            forge_inference_memory = p.override_settings.get('forge_inference_memory', shared.opts.forge_inference_memory)
+            forge_async_loading = p.override_settings.get('forge_async_loading', shared.opts.forge_async_loading)
+            forge_pin_shared_memory = p.override_settings.get('forge_pin_shared_memory', shared.opts.forge_pin_shared_memory)
+            model_memory = main_entry.total_vram - forge_inference_memory
+            main_entry.refresh_memory_management_settings(model_memory, forge_async_loading, forge_pin_shared_memory)
+
+        # backwards compatibility, fix sampler and scheduler if invalid
+        sd_samplers.fix_p_invalid_sampler_and_scheduler(p)
+
+        with profiling.Profiler():
+            res = process_images_inner(p)
+
+    finally:
+        # restore opts to original state
+        if p.override_settings_restore_afterwards:
+            for k, v in stored_opts.items():
+                if k == 'forge_additional_modules':
+                    main_entry.modules_change(v, refresh_params=False)
+                elif k == 'sd_model_checkpoint':
+                    main_entry.checkpoint_change(v)
+                else:
+                    setattr(opts, k, v)
+
+            if refresh_memory:
+                model_memory = main_entry.total_vram - shared.opts.forge_inference_memory
+                main_entry.refresh_memory_management_settings(model_memory, shared.opts.forge_async_loading, shared.opts.forge_pin_shared_memory)
 
     return res
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -823,12 +823,15 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
         memory_keys = ['forge_inference_memory', 'forge_async_loading', 'forge_pin_shared_memory']
 
         for k, v in p.override_settings.items():
+            # options for memory/modules/checkpoints are set in their dedicated functions
             if k in memory_keys:
-                temp_memory_changes[k] = v
+                mem_k = k[len('forge_'):] # remove 'forge_' prefix
+                temp_memory_changes[mem_k] = v
             elif k == 'forge_additional_modules':
                 main_entry.modules_change(v, refresh_params=False)
             elif k == 'sd_model_checkpoint':
                 main_entry.checkpoint_change(v)
+            # set all other options
             else:
                 opts.set(k, v, is_api=True, run_callbacks=False)
 
@@ -853,7 +856,7 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
                     setattr(opts, k, v)
 
             if temp_memory_changes:
-                main_entry.refresh_memory_management_settings() # will apply the re-set options
+                main_entry.refresh_memory_management_settings() # applies the set options by default
 
     return res
 

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -121,7 +121,7 @@ def make_checkpoint_manager_ui():
     bind_to_opts(ui_clip_skip, 'CLIP_stop_at_last_layers', save=False)
 
     ui_checkpoint.change(checkpoint_change, inputs=[ui_checkpoint], show_progress=False)
-    ui_vae.change(vae_change, inputs=[ui_vae], queue=False, show_progress=False)
+    ui_vae.change(modules_change, inputs=[ui_vae], queue=False, show_progress=False)
 
     return
 
@@ -221,15 +221,16 @@ def refresh_model_loading_parameters():
     return
 
 
-def checkpoint_change(ckpt_name):
+def checkpoint_change(ckpt_name, refresh_params=True):
     shared.opts.set('sd_model_checkpoint', ckpt_name)
     shared.opts.save(shared.config_filename)
 
-    refresh_model_loading_parameters()
+    if refresh_params:
+        refresh_model_loading_parameters()
     return
 
 
-def vae_change(module_names):
+def modules_change(module_names, refresh_params=True):
     modules = []
 
     for n in module_names:
@@ -239,7 +240,8 @@ def vae_change(module_names):
     shared.opts.set('forge_additional_modules', modules)
     shared.opts.save(shared.config_filename)
 
-    refresh_model_loading_parameters()
+    if refresh_params:
+        refresh_model_loading_parameters()
     return
 
 

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -165,7 +165,7 @@ def refresh_models():
 
 
 def ui_refresh_memory_management_settings(model_memory, async_loading, pin_shared_memory):
-    """ Passes precalculated 'model_memory' (from "GPU Weights" UI slider), bypassing memory calculation if only 'forge_inference_memory' passed (from API, backend, etc). """
+    """ Passes precalculated 'model_memory' from "GPU Weights" UI slider (skip redundant calculation) """
     refresh_memory_management_settings(
         async_loading=async_loading,
         pin_shared_memory=pin_shared_memory,

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -112,10 +112,11 @@ def make_checkpoint_manager_ui():
 
     mem_comps = [ui_forge_inference_memory, ui_forge_async_loading, ui_forge_pin_shared_memory]
 
-    ui_forge_inference_memory.change(refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)
-    ui_forge_async_loading.change(refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)
-    ui_forge_pin_shared_memory.change(refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)
-    Context.root_block.load(refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)
+    ui_forge_inference_memory.change(ui_refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)
+    ui_forge_async_loading.change(ui_refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)
+    ui_forge_pin_shared_memory.change(ui_refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)
+
+    Context.root_block.load(ui_refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)
 
     ui_clip_skip = gr.Slider(label="Clip skip", value=lambda: shared.opts.CLIP_stop_at_last_layers, **{"minimum": 1, "maximum": 12, "step": 1})
     bind_to_opts(ui_clip_skip, 'CLIP_stop_at_last_layers', save=False)
@@ -163,15 +164,32 @@ def refresh_models():
     return ckpt_list, module_list.keys()
 
 
-def refresh_memory_management_settings(model_memory, async_loading, pin_shared_memory):
-    inference_memory = total_vram - model_memory
+def ui_refresh_memory_management_settings(model_memory, async_loading, pin_shared_memory):
+    """ Passes precalculated 'model_memory' (from "GPU Weights" UI slider), bypassing memory calculation if only 'forge_inference_memory' passed (from API, backend, etc). """
+    refresh_memory_management_settings(
+        async_loading=async_loading,
+        pin_shared_memory=pin_shared_memory,
+        model_memory=model_memory  # Use model_memory directly from UI slider value
+    )
+
+def refresh_memory_management_settings(async_loading=None, inference_memory=None, pin_shared_memory=None, model_memory=None):
+    # Fallback to defaults if values are not passed
+    async_loading = async_loading if async_loading is not None else shared.opts.forge_async_loading
+    inference_memory = inference_memory if inference_memory is not None else shared.opts.forge_inference_memory
+    pin_shared_memory = pin_shared_memory if pin_shared_memory is not None else shared.opts.forge_pin_shared_memory
+
+    # If model_memory is provided, calculate inference memory accordingly, otherwise use inference_memory directly
+    if model_memory is None:
+        model_memory = total_vram - inference_memory
+    else:
+        inference_memory = total_vram - model_memory
 
     shared.opts.set('forge_async_loading', async_loading)
     shared.opts.set('forge_inference_memory', inference_memory)
     shared.opts.set('forge_pin_shared_memory', pin_shared_memory)
 
     stream.stream_activated = async_loading == 'Async'
-    memory_management.current_inference_memory = inference_memory * 1024 * 1024
+    memory_management.current_inference_memory = inference_memory * 1024 * 1024  # Convert MB to bytes
     memory_management.PIN_SHARED_MEMORY = pin_shared_memory == 'Shared'
 
     log_dict = dict(


### PR DESCRIPTION
## Improve API Modules Change:

**Previously**, the complete file path was required for each module specified in the 'forge_additional_modules' list.

```
'forge_additional_modules' = [
"C:\\0_SD\\stable-diffusion-webui-forge\\models\\text_encoder\\ae.safetensors",
"C:\\0_SD\\stable-diffusion-webui-forge\\models\\text_encoder\\clip_l.safetensors"
]
```

**Now**, it only requires the module name (like `sd_model_checkpoint`)

```
'forge_additional_modules' = [
"ae.safetensors",
"clip_l.safetensors"
]
```

In the process, I added a positional argument to prevent spamming `refresh_model_loading_parameters()`

---

## Restore override_settings:

I found the corresponding code in A1111, and determined the correct lines to integrate `override_settings` handling back in.

Although the code is a bit verbose, this is customized for the Forge environment to gracefully handle memory, checkpoints, and modules.