### PR TITLE
Restore embedding filepath storage.

### DIFF
--- a/backend/text_processing/textual_inversion.py
+++ b/backend/text_processing/textual_inversion.py
@@ -258,4 +258,7 @@ def create_embedding_from_data(data, name, filename='unknown embedding file', fi
     embedding.vectors = vectors
     embedding.shape = shape
 
+    if filepath:
+        embedding.filename = filepath
+
     return embedding


### PR DESCRIPTION
I don't know why filenames were removed from all extra network objects, but it seems to have been left in a half baked state for quite a while and that's less than ideal.
Restores functionality to autocomplete extension: https://github.com/DominikDoom/a1111-sd-webui-tagcomplete/issues/297