### PR TITLE
Unload all models control

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -449,6 +449,7 @@ def reload_model_weights(sd_model=None, info=None, forced_reload=False):
 
 
 def unload_model_weights(sd_model=None, info=None):
+    memory_management.unload_all_models()
     pass
 
 

--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -189,8 +189,8 @@ class UiSettings:
                     download_localization = gr.Button(value='Download localization template', elem_id="download_localization")
                     reload_script_bodies = gr.Button(value='Reload custom script bodies (No ui updates, No restart)', variant='secondary', elem_id="settings_reload_script_bodies")
                     with gr.Row():
-                        unload_sd_model = gr.Button(value='Unload SD checkpoint to RAM', elem_id="sett_unload_sd_model")
-                        reload_sd_model = gr.Button(value='Load SD checkpoint to VRAM from RAM', elem_id="sett_reload_sd_model")
+                        unload_sd_model = gr.Button(value='Unload all models', elem_id="sett_unload_sd_model")
+#                        reload_sd_model = gr.Button(value='Load SD checkpoint to VRAM from RAM', elem_id="sett_reload_sd_model")
                     with gr.Row():
                         calculate_all_checkpoint_hash = gr.Button(value='Calculate hash for all checkpoint', elem_id="calculate_all_checkpoint_hash")
                         calculate_all_checkpoint_hash_threads = gr.Number(value=1, label="Number of parallel calculations", elem_id="calculate_all_checkpoint_hash_threads", precision=0, minimum=1)
@@ -217,16 +217,16 @@ class UiSettings:
                 return handler
 
             unload_sd_model.click(
-                fn=call_func_and_return_text(sd_models.unload_model_weights, 'Unloaded the checkpoint'),
+                fn=call_func_and_return_text(sd_models.unload_model_weights, 'Unloaded all models'),
                 inputs=[],
                 outputs=[self.result]
             )
 
-            reload_sd_model.click(
-                fn=call_func_and_return_text(lambda: sd_models.send_model_to_device(shared.sd_model), 'Loaded the checkpoint'),
-                inputs=[],
-                outputs=[self.result]
-            )
+#            reload_sd_model.click(
+#                fn=call_func_and_return_text(lambda: sd_models.send_model_to_device(shared.sd_model), 'Loaded the checkpoint'),
+#                inputs=[],
+#                outputs=[self.result]
+#            )
 
             request_notifications.click(
                 fn=lambda: None,


### PR DESCRIPTION
make sd_models.unload_model_weights() do what it claims (previously **pass**)
called in two places: API unloadapi(); and the Settings > Actions page.