### PR TITLE
Make SD Models work with Override Settings 

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -828,7 +828,7 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
                 mem_k = k[len('forge_'):] # remove 'forge_' prefix
                 temp_memory_changes[mem_k] = v
             elif k == 'forge_additional_modules':
-                main_entry.modules_change(v, refresh_params=False)
+                main_entry.modules_change(v)
             elif k == 'sd_model_checkpoint':
                 main_entry.checkpoint_change(v)
             # set all other options
@@ -849,7 +849,7 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
         if p.override_settings_restore_afterwards:
             for k, v in stored_opts.items():
                 if k == 'forge_additional_modules':
-                    main_entry.modules_change(v, refresh_params=False)
+                    main_entry.modules_change(v)
                 elif k == 'sd_model_checkpoint':
                     main_entry.checkpoint_change(v)
                 else:


### PR DESCRIPTION
In my recent PR which was committed https://github.com/lllyasviel/stable-diffusion-webui-forge/pull/2027 , there were two things I overlooked:

I had suppressed a `refresh_model_loading_parameters()` call if any `forge_additional_modules` were provided as overrides.  This is wrong - If any modules are provided, it should be called.

I believed that SD Model overrides were being applied, because it printed `Model selected: {}` with the new model details, and after generation it printed `Model selected: {}` with the original model details.  Although the model settings were indeed changing, they were not taking any effect because there are a few lines which actually handle the model loading/reloading which were being called immediately before the setting were being modified, rather than after.

Aside from just moving these lines down, I felt that these are related and have better clarity grouped into a separate function.


With these changes:
- `forge_additional_modules` overrides will always take effect
- SD Model overrides will take effect

I tested gens in the UI before and after sending text2img API request, and checked the resulting metadata, monitored the CMD window - in all cases everything is behaving expectedly.