### PR TITLE
Include Extra Images via API

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -21,7 +21,7 @@ from modules import sd_samplers, deepbooru, images, scripts, ui, postprocessing,
 from modules.api import models
 from modules_forge import main_entry
 from modules.shared import opts
-from modules.processing import StableDiffusionProcessingTxt2Img, StableDiffusionProcessingImg2Img, process_images
+from modules.processing import StableDiffusionProcessingTxt2Img, StableDiffusionProcessingImg2Img, process_images, process_extra_images
 from modules.textual_inversion.textual_inversion import create_embedding
 from PIL import PngImagePlugin
 from modules.realesrgan_model import get_realesrgan_models
@@ -488,12 +488,13 @@ class Api:
                     else:
                         p.script_args = tuple(script_args) # Need to pass args as tuple here
                         processed = process_images(p)
+                    process_extra_images(processed)
                     finish_task(task_id)
                 finally:
                     shared.state.end()
                     shared.total_tqdm.clear()
 
-        b64images = list(map(encode_pil_to_base64, processed.images)) if send_images else []
+        b64images = list(map(encode_pil_to_base64, processed.images + processed.extra_images)) if send_images else []
 
         return models.TextToImageResponse(images=b64images, parameters=vars(txt2imgreq), info=processed.js())
 
@@ -559,12 +560,13 @@ class Api:
                     else:
                         p.script_args = tuple(script_args) # Need to pass args as tuple here
                         processed = process_images(p)
+                    process_extra_images(processed)
                     finish_task(task_id)
                 finally:
                     shared.state.end()
                     shared.total_tqdm.clear()
 
-        b64images = list(map(encode_pil_to_base64, processed.images)) if send_images else []
+        b64images = list(map(encode_pil_to_base64, processed.images + processed.extra_images)) if send_images else []
 
         if not img2imgreq.include_init_images:
             img2imgreq.init_images = None

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1176,6 +1176,18 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
     return res
 
 
+def process_extra_images(processed:Processed):
+    """used by API processing functions to ensure extra images are PIL image objects"""
+    extra_images = []
+    for img in processed.extra_images:
+        if isinstance(img, np.ndarray):
+            img = Image.fromarray(img)
+        if not Image.isImageType(img):
+            continue
+        extra_images.append(img)
+    processed.extra_images = extra_images
+
+
 def old_hires_fix_first_pass_dimensions(width, height):
     """old algorithm for auto-calculating first pass size"""
 


### PR DESCRIPTION
Solves https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/2051

In all (?) versions of A1111, and in maybe (?) some previous versions of Forge and/or ReForge, any and all "Extra Images" would be appended to the image results.  The most common type of Extra Images is ControlNet preprocessor maps.

I think that when ControlNet was integrated, this feature was left out by accident or there were simply bigger fish to fry.


This PR will now add extra_images to the images list for the API.

Some more explanation on what's going on...

The ControlNet preprocessor maps are initially being added to `extra_images` as numpy arrays.  I couldn't ascertain how the UI processes them, I was only able to trace back the UI behavior to [here](https://github.com/lllyasviel/stable-diffusion-webui-forge/blob/main/modules/txt2img.py#L134) - and with print statements I see the `processed.images` is (typically) a one PIL image object, and the `processed.extra_images` are a list of numpy arrays.  I don't know how the UI deals with this, but it does.  I had tried simply adding `+ processed.extra_images` in the API version, but it does not accept the numpy arrays and yields an invalid infotext error.

I made a little function that will update the `extra_images` by converting any img data which is numpy arrays to PIL image objects using `Image.fromarray()` - then, only Image objects will be set.  If there are any other types of arrays that could be converted and applied, the function could simply be updated later if necessary.