### PR TITLE
Checkpoint vae+te metadata should be in new attribute

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -214,7 +214,9 @@ class ExtraNetworksPage:
         desc = metadata.get("description", None)
         if desc is not None:
             item["description"] = desc
-        vae = metadata.get("vae", None)
+        vae = metadata.get('vae_te', None)
+        if vae is None:     # fallback to old type
+            vae = metadata.get("vae", None)
         if vae is not None:
             if isinstance(vae, str):
                 vae = [vae]

--- a/modules/ui_extra_networks_checkpoints_user_metadata.py
+++ b/modules/ui_extra_networks_checkpoints_user_metadata.py
@@ -17,7 +17,7 @@ class CheckpointUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataE
         user_metadata = self.get_user_metadata(name)
         user_metadata["description"] = desc
         user_metadata["notes"] = notes
-        user_metadata["vae"] = vae
+        user_metadata["vae_te"] = vae
         user_metadata["sd_version_str"] = 'SdVersion.' + sd_version
 
         self.write_user_metadata(name, user_metadata)
@@ -26,7 +26,12 @@ class CheckpointUserMetadataEditor(ui_extra_networks_user_metadata.UserMetadataE
         user_metadata = self.get_user_metadata(name)
         values = super().put_values_into_components(name)
         
-        vae = user_metadata.get('vae', None)
+        vae = user_metadata.get('vae_te', None)
+        if vae is None:     # fallback to old type
+            vae = user_metadata.get('vae', None)
+            if vae is not None:
+                if isinstance(vae, str):
+                    vae = [vae]
 
         version = user_metadata.get('sd_version_str', '')
         if version == '':


### PR DESCRIPTION
so the new form (a list) can be ignored by older webUIs, while the old form (a string) is unchanged.