### PR TITLE
prevent (Managed by Forge) settings from reverting to default

### DIFF
--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -83,6 +83,10 @@ class UiSettings:
             if comp == self.dummy_component:
                 continue
 
+            # don't set (Managed by Forge) options, they revert to defaults
+            if key in ["sd_model_checkpoint", "CLIP_stop_at_last_layers", "sd_vae"]:
+                continue
+
             if opts.set(key, value):
                 changed.append(key)
 

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -119,7 +119,7 @@ def make_checkpoint_manager_ui():
     Context.root_block.load(ui_refresh_memory_management_settings, inputs=mem_comps, queue=False, show_progress=False)
 
     ui_clip_skip = gr.Slider(label="Clip skip", value=lambda: shared.opts.CLIP_stop_at_last_layers, **{"minimum": 1, "maximum": 12, "step": 1})
-    bind_to_opts(ui_clip_skip, 'CLIP_stop_at_last_layers', save=False)
+    bind_to_opts(ui_clip_skip, 'CLIP_stop_at_last_layers', save=True)
 
     ui_checkpoint.change(checkpoint_change, inputs=[ui_checkpoint], show_progress=False)
     ui_vae.change(modules_change, inputs=[ui_vae], queue=False, show_progress=False)


### PR DESCRIPTION
#2082
also thanks to #2034

Also made CLIP skip setting save to config when changed. Previously it was not saved on change, but would be saved when another saveable setting was changed (for example, the checkpoint). That felt unpredictable and inconsistent.