### PR TITLE
prevent undoing refresh model load params

### DIFF
--- a/modules/sysinfo.py
+++ b/modules/sysinfo.py
@@ -237,7 +237,9 @@ def set_config(req: dict[str, Any], is_api=False, run_callbacks=True, save_confi
             main_entry.checkpoint_change(v, save=False, refresh=False)
             should_refresh_model_loading_params = True
         elif k == 'forge_additional_modules':
-            should_refresh_model_loading_params = main_entry.modules_change(v, save=False, refresh=False)
+            modules_changed = main_entry.modules_change(v, save=False, refresh=False)
+            if modules_changed:
+                should_refresh_model_loading_params = True
         elif k in memory_keys:
             mem_key = k[len('forge_'):] # remove 'forge_' prefix
             memory_changes[mem_key] = v

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -250,7 +250,7 @@ def checkpoint_change(ckpt_name:str, save=True, refresh=True):
 
 
 def modules_change(module_values:list, save=True, refresh=True) -> bool:
-    """ module values may be provided as file paths or as simply the module names """
+    """ module values may be provided as file paths, or just the module names. Returns True if modules changed. """
     modules = []
     for v in module_values:
         module_name = os.path.basename(v) # If the input is a filepath, extract the file name


### PR DESCRIPTION
In my last PR (https://github.com/lllyasviel/stable-diffusion-webui-forge/pull/2078), there was a flaw in the logic pertaining to `forge_additional_modules`, which could revert the flag `should_refresh_model_loading_params` back to `False`

Change ensures `should_refresh_model_loading_params()` is called when needed.

Improved code clarity.