### PR TITLE
Fix for the unmatched keys in DoRA

### DIFF
--- a/backend/patcher/lora.py
+++ b/backend/patcher/lora.py
@@ -25,17 +25,33 @@ def inner_str(k, prefix="", suffix=""):
     return k[len(prefix):-len(suffix)]
 
 
-def model_lora_keys_clip(model, key_map={}):
-    model_keys, key_maps = get_function('model_lora_keys_clip')(model, key_map)
+def model_lora_keys_clip(model, key_maps={}):
+    result = get_function("model_lora_keys_clip")(model, key_maps)
 
-    for model_key in model_keys:
+    if isinstance(result, tuple):
+        model_keys, key_maps = result
+    else:
+        key_maps = result
+
+    sdk = model.state_dict().keys()
+
+    for model_key in sdk:
         if model_key.endswith(".weight"):
             if model_key.startswith("t5xxl.transformer."):
-                for prefix in ['te1', 'te2', 'te3']:
+                for prefix in ["te1", "te2", "te3"]:
                     formatted = inner_str(model_key, "t5xxl.transformer.", ".weight")
                     formatted = formatted.replace(".", "_")
                     formatted = f"lora_{prefix}_{formatted}"
-                    key_map[formatted] = model_key
+                    key_maps[formatted] = model_key
+
+    # fix from comfyui updated lora code
+    k = "clip_g.transformer.text_projection.weight"
+    if k in sdk:
+        key_maps["lora_te2_text_projection"] = k
+
+    k = "clip_l.transformer.text_projection.weight"
+    if k in sdk:
+        key_maps["lora_te1_text_projection"] = k
 
     return key_maps
 


### PR DESCRIPTION
Fix for the unmatched keys in DoRA (at least the ones trained in OneTrainer).

From my tests, not having those keys affects the gen.

Error log:
```
[LORA] Loading C:\stable-diffusion-webui\models\Lora\onetrainer\abluble.safetensors for KModel with unmatched keys ['lora_te2_text_projection.alpha', 'lora_te2_text_projection.dora_scale', 'lora_te2_text_projection.lora_down.weight', 'lora_te2_text_projection.lora_up.weight']
```