### PR TITLE
Make Extension Update Checks Multi-Threaded

### DIFF
--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -106,7 +106,7 @@ def check_updates(id_task, disable_list):
     exts = [ext for ext in extensions.extensions if ext.remote is not None and ext.name not in disabled]
     shared.state.job_count = len(exts)
 
-    for ext in exts:
+    def _check_update(ext):
         shared.state.textinfo = ext.name
 
         try:
@@ -117,6 +117,14 @@ def check_updates(id_task, disable_list):
         except Exception:
             errors.report(f"Error checking updates for {ext.name}", exc_info=True)
 
+    threads = []
+    for ext in exts:
+        thread = threading.Thread(target=_check_update, args=(ext,))
+        threads.append(thread)
+        thread.start()   
+
+    for thread in threads:
+        thread.join()
         shared.state.nextjob()
 
     return extension_table(), ""


### PR DESCRIPTION
#### What does this PR do?
- Use the `threading` package to make the **Check for updates** parallel

#### Feature
- Now it checks the updates of all Extensions at the same time, instead of checking one by one, thus drastically reducing the waiting time

#### Test
- On my installation, checking 11 Extensions only took `1.1 sec`. And after pressing **Apply and restart UI**, everything updates and works correctly.