### PR TITLE
Validate checkpoints in checkpoint_change()

### DIFF
--- a/modules/sysinfo.py
+++ b/modules/sysinfo.py
@@ -232,8 +232,6 @@ def set_config(req: dict[str, Any], is_api=False, run_callbacks=True, save_confi
         # checkpoints, modules, and options pertaining to memory management are managed in dedicated functions
         # If values for these options change, call refresh_model_loading_parameters()
         if k == 'sd_model_checkpoint':
-            if v is not None and v not in sd_models.checkpoint_aliases:
-                raise RuntimeError(f"model {v!r} not found")
             main_entry.checkpoint_change(v, save=False, refresh=False)
             should_refresh_model_loading_params = True
         elif k == 'forge_additional_modules':

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -240,6 +240,9 @@ def refresh_model_loading_parameters():
 
 
 def checkpoint_change(ckpt_name:str, save=True, refresh=True):
+    if ckpt_name is not None and ckpt_name not in sd_models.checkpoint_aliases:
+        raise RuntimeError(f"model {ckpt_name!r} not found")
+
     shared.opts.set('sd_model_checkpoint', ckpt_name)
 
     if save:


### PR DESCRIPTION
I believe this solves https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/2089


_EDITED comment below **in bold text**_

Upon reviewing the relevant code in this issue, I can see that the option `hr_checkpoint_name` was not **100% flawlessly ** validating the checkpoint before applying `checkpoint_change()`.  **in [processing module line 1272](https://github.com/lllyasviel/stable-diffusion-webui-forge/blob/main/modules/processing.py#L1272) I believe that `get_closet_checkpoint_match()` may possibly return an invalid value?**


First pass `sd_checkpoint_model` checkpoints were being validated outside `checkpoint_change()`.

Rather than creating another duplicate validation step specifically for `hr_checkpoint_name` outside the function, simply validate all checkpoints within `checkpoint_change()`