### PR TITLE
Automatically enable ztSNR when applicable

### DIFF
--- a/backend/loader.py
+++ b/backend/loader.py
@@ -244,6 +244,7 @@ def split_state_dict(sd, additional_state_dicts: list = None):
 
     guess.clip_target = guess.clip_target(sd)
     guess.model_type = guess.model_type(sd)
+    guess.ztsnr = 'ztsnr' in sd
 
     state_dict = {
         guess.unet_target: try_filter_state_dict(sd, guess.unet_key_prefix),

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -974,7 +974,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             sd_models.apply_alpha_schedule_override(p.sd_model, p)
 
             sigmas_backup = None
-            if opts.sd_noise_schedule == "Zero Terminal SNR" and p is not None:
+            if (opts.sd_noise_schedule == "Zero Terminal SNR" or (hasattr(p.sd_model.model_config, 'ztsnr') and p.sd_model.model_config.ztsnr)) and p is not None:
                 p.extra_generation_params['Noise Schedule'] = opts.sd_noise_schedule
                 sigmas_backup = p.sd_model.forge_objects.unet.model.predictor.sigmas
                 p.sd_model.forge_objects.unet.model.predictor.set_sigmas(rescale_zero_terminal_snr_sigmas(p.sd_model.forge_objects.unet.model.predictor.sigmas))


### PR DESCRIPTION
Title. Follow-up to https://github.com/lllyasviel/stable-diffusion-webui-forge/pull/2115.

Marking as a draft for now since this may be handled differently.

Related:
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16569
https://github.com/Panchovix/stable-diffusion-webui-reForge/pull/150