### PR TITLE
properly load/save 'Use same choices' infotext

### DIFF
--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -456,6 +456,12 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
         if sorted(modules) != sorted(basename_modules):
             res['VAE/TE'] = modules
 
+    # if 'Use same choices' was the selection for Hires VAE / Text Encoder, it will be the only option written
+    # but will not have matched the known modules, so will not be in hr_modules
+    if 'Hires Module 1' in res:
+        if res['Hires Module 1'] == 'Use same choices':
+            hr_modules = ['Use same choices']
+
     res['Hires VAE/TE'] = hr_modules
 
     return res

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -928,7 +928,7 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
             if state.interrupted or state.stopping_generation:
                 break
 
-            sd_models.reload_model_weights()  # model can be changed for example by refiner
+            sd_models.forge_model_reload()  # model can be changed for example by refiner, hiresfix fix
 
             p.sd_model.forge_objects = p.sd_model.forge_objects_original.shallow_copy()
             p.prompts = p.all_prompts[n * p.batch_size:(n + 1) * p.batch_size]

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1282,7 +1282,9 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
                 self.extra_generation_params["Hires checkpoint"] = self.hr_checkpoint_info.short_title
 
             if isinstance(self.hr_additional_modules, list) and len(self.hr_additional_modules) > 0:
-                if 'Use same choices' not in self.hr_additional_modules:
+                if 'Use same choices' in self.hr_additional_modules:
+                    self.extra_generation_params[f'Hires Module 1'] = 'Use same choices'
+                else:
                     for i, m in enumerate(self.hr_additional_modules):
                         self.extra_generation_params[f'Hires Module {i+1}'] = os.path.splitext(os.path.basename(m))[0]
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1283,7 +1283,7 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 
             if isinstance(self.hr_additional_modules, list) and len(self.hr_additional_modules) > 0:
                 if 'Use same choices' in self.hr_additional_modules:
-                    self.extra_generation_params[f'Hires Module 1'] = 'Use same choices'
+                    self.extra_generation_params['Hires Module 1'] = 'Use same choices'
                 else:
                     for i, m in enumerate(self.hr_additional_modules):
                         self.extra_generation_params[f'Hires Module {i+1}'] = os.path.splitext(os.path.basename(m))[0]


### PR DESCRIPTION
previously mistaken logic treated that option same as an empty selection.
also re-enabled model loading during batch iterations. Previously *Batch count*, when used with a different highresfix model, would stay on the second pass model