### PR TITLE
Properly load/save infotext for empty selection of hrfix additional modules

### DIFF
--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -456,13 +456,18 @@ Steps: 20, Sampler: Euler a, CFG scale: 7, Seed: 965400086, Size: 512x512, Model
         if sorted(modules) != sorted(basename_modules):
             res['VAE/TE'] = modules
 
-    # if 'Use same choices' was the selection for Hires VAE / Text Encoder, it will be the only option written
-    # but will not have matched the known modules, so will not be in hr_modules
+    # if 'Use same choices' was the selection for Hires VAE / Text Encoder, it will be the only Hires Module
+    # if the selection was empty, it will be the only Hires Module, saved as 'Built-in'
     if 'Hires Module 1' in res:
         if res['Hires Module 1'] == 'Use same choices':
             hr_modules = ['Use same choices']
+        elif res['Hires Module 1'] == 'Built-in':
+            hr_modules = []
 
-    res['Hires VAE/TE'] = hr_modules
+        res['Hires VAE/TE'] = hr_modules
+    else:
+        # no Hires Module infotext, use default
+        res['Hires VAE/TE'] = ['Use same choices']
 
     return res
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1281,8 +1281,10 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 
                 self.extra_generation_params["Hires checkpoint"] = self.hr_checkpoint_info.short_title
 
-            if isinstance(self.hr_additional_modules, list) and len(self.hr_additional_modules) > 0:
-                if 'Use same choices' in self.hr_additional_modules:
+            if isinstance(self.hr_additional_modules, list):
+                if self.hr_additional_modules == []:
+                    self.extra_generation_params['Hires Module 1'] = 'Built-in'
+                elif 'Use same choices' in self.hr_additional_modules:
                     self.extra_generation_params['Hires Module 1'] = 'Use same choices'
                 else:
                     for i, m in enumerate(self.hr_additional_modules):


### PR DESCRIPTION
empty selection for *Hires VAE / TE* means 'use modules built-in to the model file', same as top-row VAE / TE selection. But this must be written to infotext as something, to distinguish from the non-HiRes case which, of course, writes no Hires Modules.