### PR TITLE
Improve option handling (sd_model_checkpoint / forge_additional_modules)

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1402,24 +1402,24 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 
             reload = False
             if 'Use same choices' not in self.hr_additional_modules:
-                if sorted(self.hr_additional_modules) != sorted(fp_additional_modules):
-                    main_entry.modules_change(self.hr_additional_modules, save=False, refresh=False)
+                modules_changed = main_entry.modules_change(self.hr_additional_modules, save=False, refresh=False)
+                if modules_changed:
                     reload = True
 
             if self.hr_checkpoint_name and self.hr_checkpoint_name != 'Use same checkpoint':
-                if self.hr_checkpoint_name != fp_checkpoint:
+                checkpoint_changed = main_entry.checkpoint_change(self.hr_checkpoint_name, save=False, refresh=False)
+                if checkpoint_changed:
                     self.firstpass_use_distilled_cfg_scale = self.sd_model.use_distilled_cfg_scale
-
-                    main_entry.checkpoint_change(self.hr_checkpoint_name, save=False, refresh=False)
                     reload = True
-            
+
             if reload:
                 try:
                     main_entry.refresh_model_loading_parameters()
                     sd_models.forge_model_reload()
                 finally:
                     main_entry.modules_change(fp_additional_modules, save=False, refresh=False)
-                    main_entry.checkpoint_change(fp_checkpoint, save=False)
+                    main_entry.checkpoint_change(fp_checkpoint, save=False, refresh=False)
+                    main_entry.refresh_model_loading_parameters()
 
             if self.sd_model.use_distilled_cfg_scale:
                 self.extra_generation_params['Hires Distilled CFG Scale'] = self.hr_distilled_cfg

--- a/modules/sysinfo.py
+++ b/modules/sysinfo.py
@@ -234,8 +234,9 @@ def set_config(req: dict[str, Any], is_api=False, run_callbacks=True, save_confi
         if k == 'sd_model_checkpoint':
             if v is not None and v not in sd_models.checkpoint_aliases:
                 raise RuntimeError(f"model {v!r} not found")
-            main_entry.checkpoint_change(v, save=False, refresh=False)
-            should_refresh_model_loading_params = True
+            checkpoint_changed = main_entry.checkpoint_change(v, save=False, refresh=False)
+            if checkpoint_changed:
+                should_refresh_model_loading_params = True
         elif k == 'forge_additional_modules':
             modules_changed = main_entry.modules_change(v, save=False, refresh=False)
             if modules_changed:

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -258,7 +258,7 @@ def modules_change(module_values:list, save=True, refresh=True) -> bool:
             modules.append(module_list[module_name])
     
     # skip further processing if value unchanged
-    if modules == shared.opts.data.get('forge_additional_modules'):
+    if sorted(modules) == sorted(shared.opts.data.get('forge_additional_modules', [])):
         return False
 
     shared.opts.set('forge_additional_modules', modules)

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -241,8 +241,8 @@ def refresh_model_loading_parameters():
 
 def checkpoint_change(ckpt_name:str, save=True, refresh=True):
     """ checkpoint name can be a number of valid aliases. Returns True if checkpoint changed. """
-    new_ckpt_info = sd_models.checkpoint_aliases.get(ckpt_name)
-    current_ckpt_info = sd_models.checkpoint_aliases.get(shared.opts.data.get('sd_model_checkpoint', ''))
+    new_ckpt_info = sd_models.get_closet_checkpoint_match(ckpt_name)
+    current_ckpt_info = sd_models.get_closet_checkpoint_match(shared.opts.data.get('sd_model_checkpoint', ''))
     if new_ckpt_info == current_ckpt_info:
         return False
 

--- a/modules_forge/main_entry.py
+++ b/modules_forge/main_entry.py
@@ -240,13 +240,19 @@ def refresh_model_loading_parameters():
 
 
 def checkpoint_change(ckpt_name:str, save=True, refresh=True):
+    """ checkpoint name can be a number of valid aliases. Returns True if checkpoint changed. """
+    new_ckpt_info = sd_models.checkpoint_aliases.get(ckpt_name)
+    current_ckpt_info = sd_models.checkpoint_aliases.get(shared.opts.data.get('sd_model_checkpoint', ''))
+    if new_ckpt_info == current_ckpt_info:
+        return False
+
     shared.opts.set('sd_model_checkpoint', ckpt_name)
 
     if save:
         shared.opts.save(shared.config_filename)
     if refresh:
         refresh_model_loading_parameters()
-    return
+    return True
 
 
 def modules_change(module_values:list, save=True, refresh=True) -> bool:


### PR DESCRIPTION
- When comparing inbound setting for `forge_additional_modules` to the stored setting, the lists could have the same values in them but it would trigger `refresh_model_parameters()` if they were in different orders.  Now, the values are sorted when comparing them.
- A wide variety of values are accepted and valid for `sd_model_checkpoint`.  Because of this, when checking if inbound setting for `sd_model_checkpoint` is equivelant to the current setting, these would often not match even if it is for the same model.  I've added some lines that gets a consistent value from a valid checkpoint name/alias/etc, as well as for the current model, and it will compare these.  This will resolve many cases where the same model is being reloaded unnecessarily.

**Edit** - Additionally:
- `hr_checkpoint_name` is now compared with the current checkpoint by the same method, ensuring an apples to apples comparison.
- Updated the handling of `hr_additional_modules` to let the comparison/application be handled within `modules_change()`
- In the `finally` block, explicitly call `main_entry.refresh_model_loading_parameters()` in case the checkpoint does not change (which would skip "refresh")