### PR TITLE
avoid potential unnecessary model load with hiresfix quickbutton

### DIFF
--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -93,7 +93,6 @@ def txt2img_upscale_function(id_task: str, request: gr.Request, gallery, gallery
     p.extra_generation_params['Original Size'] = f'{args[8]}x{args[7]}'
 
     p.override_settings['save_images_before_highres_fix'] = False
-    p.highresfix_quick = True
 
     with closing(p):
         processed = modules.scripts.scripts_txt2img.run(p, *p.script_args)


### PR DESCRIPTION
previously added an attribute to know when using hiresfix quickbutton, not noticing that one already existed. Removed, and corrected where it was used. Also added check (using correct attribute) to avoid an unnecessary model load when using the quickbutton.