### PR TITLE
block some settings from extra_options for txt2img/img2img

### DIFF
--- a/extensions-builtin/extra-options-section/scripts/extra_options_section.py
+++ b/extensions-builtin/extra-options-section/scripts/extra_options_section.py
@@ -25,6 +25,11 @@ class ExtraOptionsSection(scripts.Script):
         extra_options = shared.opts.extra_options_img2img if is_img2img else shared.opts.extra_options_txt2img
         elem_id_tabname = "extra_options_" + ("img2img" if is_img2img else "txt2img")
 
+        not_allowed = ['sd_model_checkpoint', 'CLIP_stop_at_last_layers', 'forge_additional_modules']
+        for na in not_allowed:
+            if na in extra_options:
+                extra_options.remove(na)
+
         mapping = {k: v for v, k in infotext_utils.infotext_to_setting_name_mapping}
 
         with gr.Blocks() as interface:

--- a/extensions-builtin/extra-options-section/scripts/extra_options_section.py
+++ b/extensions-builtin/extra-options-section/scripts/extra_options_section.py
@@ -25,7 +25,7 @@ class ExtraOptionsSection(scripts.Script):
         extra_options = shared.opts.extra_options_img2img if is_img2img else shared.opts.extra_options_txt2img
         elem_id_tabname = "extra_options_" + ("img2img" if is_img2img else "txt2img")
 
-        not_allowed = ['sd_model_checkpoint', 'CLIP_stop_at_last_layers', 'forge_additional_modules']
+        not_allowed = ['sd_model_checkpoint', 'sd_vae', 'CLIP_stop_at_last_layers', 'forge_additional_modules']
         for na in not_allowed:
             if na in extra_options:
                 extra_options.remove(na)


### PR DESCRIPTION
There are various negative effects if these settings are allowed in the extra options for txt2img or img2img. This PR removes them from the extra_options lists at load time.

`sd_model_checkpoint` and `CLIP_stop_at_last_layers` will invisibly override main UI settings, leading to confusing behaviour
`sd_vae` doesn't seem harmful, but can create an empty block in the UI section
`forge_additional_modules` causes an error that prevents the UI from loading

#2205
