### PR TITLE
Only use .yaml config prediction if actually set

### DIFF
--- a/backend/loader.py
+++ b/backend/loader.py
@@ -321,7 +321,7 @@ def forge_loader(sd, additional_state_dicts=None):
             yaml_config_prediction_type = 'v_prediction'
 
     if has_prediction_type:
-        if yaml_config_prediction_type is not None:
+        if yaml_config_prediction_type:
             huggingface_components['scheduler'].config.prediction_type = yaml_config_prediction_type
         else:
             huggingface_components['scheduler'].config.prediction_type = prediction_types.get(estimated_config.model_type.name, huggingface_components['scheduler'].config.prediction_type)


### PR DESCRIPTION
Should have been simply comparing if the value is truthy here, not just if `None`.