### PR TITLE
Add a flag to skip initializing google_blockly

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -15,6 +15,7 @@ parser.add_argument("--update-check", action='store_true', help="launch.py argum
 parser.add_argument("--test-server", action='store_true', help="launch.py argument: configure server for testing")
 parser.add_argument("--log-startup", action='store_true', help="launch.py argument: print a detailed log of what's happening at startup")
 parser.add_argument("--skip-prepare-environment", action='store_true', help="launch.py argument: skip all environment preparation")
+parser.add_argument("--skip-google-blockly", action='store_true', help="launch.py argument: do not initialize google blockly modules")
 parser.add_argument("--skip-install", action='store_true', help="launch.py argument: skip installation of packages")
 parser.add_argument("--dump-sysinfo", action='store_true', help="launch.py argument: dump limited sysinfo file (without information about extensions, options) to disk and quit")
 parser.add_argument("--loglevel", type=str, help="log level; one of: CRITICAL, ERROR, WARNING, INFO, DEBUG", default=None)

--- a/modules/initialize.py
+++ b/modules/initialize.py
@@ -133,8 +133,9 @@ def initialize_rest(*, reload_script_modules=False):
     extra_networks.register_default_extra_networks()
     startup_timer.record("initialize extra networks")
 
-    from modules_forge import google_blockly
-    google_blockly.initialization()
-    startup_timer.record("initialize google blockly")
+    if not cmd_opts.skip_google_blockly:
+        from modules_forge import google_blockly
+        google_blockly.initialization()
+        startup_timer.record("initialize google blockly")
 
     return


### PR DESCRIPTION
This PR adds a new **cmd_args**, `--skip-google-blockly`, that allows users to skip loading the **Google Blockly** modules, which only adds like 2 samplers anyway afaik

Simply add the flag after the **COMMANDLINE_ARGS** in `webui-user.bat` like other args

<hr>

I have no comment on the *"allegations."* But loading the `google_blockly` sure takes its sweet time every single launch **and** `Reload UI`...

<p align="center">
<img src="https://github.com/user-attachments/assets/d0576054-678e-411c-a620-9f5f6dd6036a"><br>
<code>before</code>
</p>

<p align="center">
<img src="https://github.com/user-attachments/assets/16419aa0-3729-4128-94eb-5b003a96b0f2"><br>
<code>after</code>
</p>
