### PR TITLE
fix/workaround for potential memory leak

### DIFF
--- a/backend/memory_management.py
+++ b/backend/memory_management.py
@@ -560,6 +560,11 @@ def unload_model_clones(model):
 
 
 def free_memory(memory_required, device, keep_loaded=[], free_all=False):
+    # this check fully unloads any 'abandoned' models
+    for i in range(len(current_loaded_models) - 1, -1, -1):
+        if sys.getrefcount(current_loaded_models[i].model) <= 2:
+            current_loaded_models.pop(i).model_unload(avoid_model_moving=True)
+
     if free_all:
         memory_required = 1e30
         print(f"[Unload] Trying to free all memory for {device} with {len(keep_loaded)} models keep loaded ... ", end="")

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -449,12 +449,7 @@ def reload_model_weights(sd_model=None, info=None, forced_reload=False):
 
 
 def unload_model_weights(sd_model=None, info=None):
-    for i in range(len(memory_management.current_loaded_models)):
-        memory_management.current_loaded_models.pop(0).model_unload(avoid_model_moving=True)
-
-    memory_management.soft_empty_cache()
-    gc.collect()
-
+    memory_management.unload_all_models()
     return
 
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -449,8 +449,13 @@ def reload_model_weights(sd_model=None, info=None, forced_reload=False):
 
 
 def unload_model_weights(sd_model=None, info=None):
-    memory_management.unload_all_models()
-    pass
+    for i in range(len(memory_management.current_loaded_models)):
+        memory_management.current_loaded_models.pop(0).model_unload(avoid_model_moving=True)
+
+    memory_management.soft_empty_cache()
+    gc.collect()
+
+    return
 
 
 def apply_token_merging(sd_model, token_merging_ratio):


### PR DESCRIPTION
the `free_memory` function in `backend/memory_management.py` only unloads models from the torch device, and preferentially moves some things to the offload device. So if a model has previously been moved off the torch device, it will not be fully unloaded. On my computer this happens with text encoders (**JointTextEncoder** model type, I've never seen an extra **KModel** or **IntegratedAutoencoderKL**), *every* new checkpoint load. Going back to a previously used checkpoint also results in another copy, not reuse of the one that already exists. Committed memory increases until there is no more available.

This PR adds a few lines to force unload these abandoned models. Possibly not the ideal fix, but it seems like a reasonable safety check to have even if a better fix is found.

~Also made the `sd_models.unload_model_weights()` function more aggressive - it fully unloads all models. This function is used in two places:~
* ~[Unload all models] button in *Settings > Actions*~
* ~API: `unloadapi()`~
