### PR TITLE
Chasing save issues

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import datetime, time
+import datetime
 import functools
 import pytz
 import io
@@ -740,7 +740,7 @@ def save_image(image, path, basename, seed=None, prompt=None, extension='png', i
 
     fullfn_without_extension = _atomically_save_image(image, fullfn_without_extension, extension)
     fullfn = fullfn_without_extension + extension
-    image.already_saved_as = f"{fullfn}\?{time.process_time_ns()}"
+    image.already_saved_as = fullfn
 
     oversize = image.width > opts.target_side_length or image.height > opts.target_side_length
     if opts.export_for_4chan and (oversize or os.stat(fullfn).st_size > opts.img_downscale_threshold * 1024 * 1024):

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -118,7 +118,7 @@ def txt2img_upscale_function(id_task: str, request: gr.Request, gallery, gallery
     else:
         geninfo["infotexts"][gallery_index] = processed.info
 
-    return gr.Gallery(new_gallery, selected_index=new_index), json.dumps(geninfo), plaintext_to_html(processed.info), plaintext_to_html(processed.comments, classname="comments")
+    return new_gallery, json.dumps(geninfo), plaintext_to_html(processed.info), plaintext_to_html(processed.comments, classname="comments")
 
 
 def txt2img_function(id_task: str, request: gr.Request, *args):

--- a/modules/txt2img.py
+++ b/modules/txt2img.py
@@ -106,6 +106,7 @@ def txt2img_upscale_function(id_task: str, request: gr.Request, gallery, gallery
     new_gallery = []
     for i, image in enumerate(gallery):
         if insert or i != gallery_index:
+            image[0].already_saved_as = image[0].filename.rsplit('?', 1)[0]
             new_gallery.append(image)
         if i == gallery_index:
             new_gallery.extend(processed.images)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -470,6 +470,12 @@ def create_ui():
             toprow.prompt.submit(**txt2img_args)
             toprow.submit.click(**txt2img_args)
 
+            def select_gallery_image(index):
+                index = int(index)
+                if getattr(shared.opts, 'hires_button_gallery_insert', False):
+                    index += 1
+                return gr.update(selected_index=index)
+            
             txt2img_upscale_inputs = txt2img_inputs[0:1] + [output_panel.gallery, dummy_component_number, output_panel.generation_info] + txt2img_inputs[1:]
             output_panel.button_upscale.click(
                 fn=wrap_gradio_gpu_call(modules.txt2img.txt2img_upscale, extra_outputs=[None, '', '']),
@@ -477,7 +483,7 @@ def create_ui():
                 inputs=txt2img_upscale_inputs,
                 outputs=txt2img_outputs,
                 show_progress=False,
-            )
+            ).then(fn=select_gallery_image, js="selected_gallery_index", inputs=[dummy_component], outputs=[output_panel.gallery])
 
             res_switch_btn.click(lambda w, h: (h, w), inputs=[width, height], outputs=[width, height], show_progress=False)
 

--- a/modules/ui_tempdir.py
+++ b/modules/ui_tempdir.py
@@ -44,9 +44,11 @@ def check_tmp_file(gradio_app, filename):
 
 def save_pil_to_file(pil_image, cache_dir=None, format="png"):
     already_saved_as = getattr(pil_image, 'already_saved_as', None)
-    if already_saved_as and os.path.isfile(already_saved_as.rsplit('\\?')[0]):
+    if already_saved_as and os.path.isfile(already_saved_as):
         register_tmp_file(shared.demo, already_saved_as)
-        return already_saved_as
+        filename_with_mtime = f'{already_saved_as}?{os.path.getmtime(already_saved_as)}'
+        register_tmp_file(shared.demo, filename_with_mtime)
+        return filename_with_mtime
 
     if shared.opts.temp_dir:
         dir = shared.opts.temp_dir

--- a/modules/ui_tempdir.py
+++ b/modules/ui_tempdir.py
@@ -44,11 +44,9 @@ def check_tmp_file(gradio_app, filename):
 
 def save_pil_to_file(pil_image, cache_dir=None, format="png"):
     already_saved_as = getattr(pil_image, 'already_saved_as', None)
-    if already_saved_as and os.path.isfile(already_saved_as):
+    if already_saved_as and os.path.isfile(already_saved_as.rsplit('\\?')[0]):
         register_tmp_file(shared.demo, already_saved_as)
-        filename_with_mtime = f'{already_saved_as}?{os.path.getmtime(already_saved_as)}'
-        register_tmp_file(shared.demo, filename_with_mtime)
-        return filename_with_mtime
+        return already_saved_as
 
     if shared.opts.temp_dir:
         dir = shared.opts.temp_dir


### PR DESCRIPTION
* added `already_saved_as` attribute to images in gallery after use of highresfix quick button - fixes long-standing, apparently unnoticed, issue where saving image/ opening in new tab from context menu would lose the proper filename after quickbutton use.
* ~tweaked tmp pil file handling to work with new image saving (intended to avoid gradio displaying old images) which had caused an issue where saving image/ opening in new tab from context menu would not have the proper filename.~
* different method to select new image after using hiresfix quickbutton with insert option
* partial revert of previously updated image saving, to avoid changing tmp pil file handling (which I wasn't fully confident was correct, though it seemed to work). Now a generation overwriting a previously saved image might not update gradio gallery, same as pre-previous-update behaviour.