### PR TITLE
Add source_text_component to Results paste buttons

### DIFF
--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -15,17 +15,16 @@ import modules.infotext_utils as parameters_copypaste
 folder_symbol = '\U0001f4c2'  # 📂
 refresh_symbol = '\U0001f504'  # 🔄
 
-
 def update_generation_info(generation_info, html_info, img_index):
     try:
         generation_info = json.loads(generation_info)
         if img_index < 0 or img_index >= len(generation_info["infotexts"]):
-            return html_info, gr.update()
-        return plaintext_to_html(generation_info["infotexts"][img_index]), gr.update()
+            return html_info, gr.update(), html_info
+        return plaintext_to_html(generation_info["infotexts"][img_index]), gr.update(), generation_info["infotexts"][img_index]
     except Exception:
         pass
     # if the json parse or anything else fails, just return the old html_info
-    return html_info, gr.update()
+    return html_info, gr.update(), html_info
 
 
 def plaintext_to_html(text, classname=None):
@@ -154,6 +153,7 @@ class OutputPanel:
     gallery = None
     generation_info = None
     infotext = None
+    infotext_plaintext = None
     html_log = None
     button_upscale = None
 
@@ -217,13 +217,14 @@ def create_output_panel(tabname, outdir, toprow=None):
                     res.html_log = gr.HTML(elem_id=f'html_log_{tabname}', elem_classes="html-log")
 
                     res.generation_info = gr.Textbox(visible=False, elem_id=f'generation_info_{tabname}')
+                    res.infotext_plaintext = gr.Textbox(visible=False, elem_id=f'infotext_plaintext_{tabname}')
                     if tabname == 'txt2img' or tabname == 'img2img':
                         generation_info_button = gr.Button(visible=False, elem_id=f"{tabname}_generation_info_button")
                         generation_info_button.click(
                             fn=update_generation_info,
                             _js="function(x, y, z){ return [x, y, selected_gallery_index()] }",
                             inputs=[res.generation_info, res.infotext, res.infotext],
-                            outputs=[res.infotext, res.infotext],
+                            outputs=[res.infotext, res.infotext, res.infotext_plaintext],
                             show_progress=False,
                         )
 
@@ -261,6 +262,7 @@ def create_output_panel(tabname, outdir, toprow=None):
             else:
                 res.generation_info = gr.HTML(elem_id=f'html_info_x_{tabname}')
                 res.infotext = gr.HTML(elem_id=f'html_info_{tabname}', elem_classes="infotext")
+                res.infotext = gr.HTML(elem_id=f'html_info_pt_{tabname}', elem_classes="infotext_plaintext")
                 res.html_log = gr.HTML(elem_id=f'html_log_{tabname}')
 
             paste_field_names = []
@@ -271,7 +273,7 @@ def create_output_panel(tabname, outdir, toprow=None):
 
             for paste_tabname, paste_button in buttons.items():
                 parameters_copypaste.register_paste_params_button(parameters_copypaste.ParamBinding(
-                    paste_button=paste_button, tabname=paste_tabname, source_tabname="txt2img" if tabname == "txt2img" else None, source_image_component=res.gallery,
+                    paste_button=paste_button, tabname=paste_tabname, source_tabname="txt2img" if tabname == "txt2img" else None, source_text_component=res.infotext_plaintext, source_image_component=res.gallery,
                     paste_field_names=paste_field_names
                 ))
 

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -262,8 +262,8 @@ def create_output_panel(tabname, outdir, toprow=None):
             else:
                 res.generation_info = gr.HTML(elem_id=f'html_info_x_{tabname}')
                 res.infotext = gr.HTML(elem_id=f'html_info_{tabname}', elem_classes="infotext")
-                res.infotext = gr.HTML(elem_id=f'html_info_pt_{tabname}', elem_classes="infotext_plaintext")
-                res.html_log = gr.HTML(elem_id=f'html_log_{tabname}')
+                res.infotext_plaintext = gr.HTML(visible=False, elem_id=f'infotext_plaintext_{tabname}', elem_classes="infotext")
+                res.html_log = gr.HTML(elem_id=f'html_log_{tabname}', elem_classes="html-log")
 
             paste_field_names = []
             if tabname == "txt2img":


### PR DESCRIPTION
Adds a source_text_component to the Results panel paste buttons' ParamBinding so that the `callable` fields are correctly pasted.

This allows sampling method, schedule type, styles, etc (all fields that are defined mostly as lambdas) to be correctly set when pasting.

There might be a gotcha; the default config value for `send_seed` is True, but prior to this fix, the seed was not getting sent regardless of the value.  With the fix, people would need to change the send_seed value to maintain their current workflow.
