### PR TITLE
Don't duplicate samplers when adding

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -65,8 +65,8 @@ def add_sampler(sampler):
     global all_samplers, all_samplers_map
     if sampler.name not in [x.name for x in all_samplers]:
         all_samplers.append(sampler)
-    all_samplers_map = {x.name: x for x in all_samplers}
-    set_samplers()
+        all_samplers_map = {x.name: x for x in all_samplers}
+        set_samplers()
     return
 
 

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -63,7 +63,8 @@ def set_samplers():
 
 def add_sampler(sampler):
     global all_samplers, all_samplers_map
-    all_samplers.append(sampler)
+    if sampler.name not in [x.name for x in all_samplers]:
+        all_samplers.append(sampler)
     all_samplers_map = {x.name: x for x in all_samplers}
     set_samplers()
     return


### PR DESCRIPTION
Simple check to avoid continually adding samplers to list.

As far as I know, the only samplers that add through this method are the Flux Realistic ones, but you can notice them duplicated for every UI reload.

#2351 