### PR TITLE
Respect send seed

### DIFF
--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -174,8 +174,9 @@ def connect_paste_params_buttons():
             )
 
         if binding.source_text_component is not None and fields is not None:
-            # get all the fields except seed if option set
-            filtered_fields = [f for f in fields if f[1] != "Seed"] if not shared.opts.send_seed else fields
+            # get all the fields except those the user has configured
+            dont_paste_fileds = (["Seed"] if not shared.opts.send_seed else []) + (["Size-1", "Size-2"] if not shared.opts.send_size else [])
+            filtered_fields = [f for f in fields if f[1] not in dont_paste_fileds]
             connect_paste(binding.paste_button, filtered_fields, binding.source_text_component, override_settings_component, binding.tabname)
 
         if binding.source_tabname is not None and fields is not None:

--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -174,7 +174,9 @@ def connect_paste_params_buttons():
             )
 
         if binding.source_text_component is not None and fields is not None:
-            connect_paste(binding.paste_button, fields, binding.source_text_component, override_settings_component, binding.tabname)
+            # get all the fields except seed if option set
+            filtered_fields = [f for f in fields if f[1] != "Seed"] if not shared.opts.send_seed else fields
+            connect_paste(binding.paste_button, filtered_fields, binding.source_text_component, override_settings_component, binding.tabname)
 
         if binding.source_tabname is not None and fields is not None:
             paste_field_names = ['Prompt', 'Negative prompt', 'Steps', 'Face restoration'] + (["Seed"] if shared.opts.send_seed else []) + binding.paste_field_names

--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -175,11 +175,11 @@ def connect_paste_params_buttons():
 
         if binding.source_text_component is not None and fields is not None:
             # get all the fields except those the user has configured
-            dont_paste_fileds = (["Seed"] if not shared.opts.send_seed else []) + (["Size-1", "Size-2"] if not shared.opts.send_size else [])
-            filtered_fields = [f for f in fields if f[1] not in dont_paste_fileds]
+            dont_paste_fields = (["Seed"] if not shared.opts.send_seed else []) + (["Size-1", "Size-2"] if not shared.opts.send_size else [])
+            filtered_fields = [f for f in fields if f[1] not in dont_paste_fields]
             connect_paste(binding.paste_button, filtered_fields, binding.source_text_component, override_settings_component, binding.tabname)
 
-        if binding.source_tabname is not None and fields is not None:
+        elif binding.source_tabname is not None and fields is not None:
             paste_field_names = ['Prompt', 'Negative prompt', 'Steps', 'Face restoration'] + (["Seed"] if shared.opts.send_seed else []) + binding.paste_field_names
             binding.paste_button.click(
                 fn=lambda *x: x,

--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -343,8 +343,8 @@ options_templates.update(options_section(('ui', "User interface", "ui"), {
     "gradio_theme": OptionInfo("Default", "Gradio theme", ui_components.DropdownEditable, lambda: {"choices": ["Default"] + shared_gradio_themes.gradio_hf_hub_themes}).info("you can also manually enter any of themes from the <a href='https://huggingface.co/spaces/gradio/theme-gallery'>gallery</a>.").needs_reload_ui(),
     "gradio_themes_cache": OptionInfo(True, "Cache gradio themes locally").info("disable to update the selected Gradio theme"),
     "show_progress_in_title": OptionInfo(True, "Show generation progress in window title."),
-    "send_seed": OptionInfo(True, "Send seed when sending prompt or image to other interface"),
-    "send_size": OptionInfo(True, "Send size when sending prompt or image to another interface"),
+    "send_seed": OptionInfo(True, "Send seed when sending prompt or image to other interface").needs_reload_ui(),
+    "send_size": OptionInfo(True, "Send size when sending prompt or image to another interface").needs_reload_ui(),
     "enable_reloading_ui_scripts": OptionInfo(False, "Reload UI scripts when using Reload UI option").info("useful for developing: if you make changes to UI scripts code, it is applied when the UI is reloded."),
 
 }))

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -19,12 +19,12 @@ def update_generation_info(generation_info, html_info, img_index):
     try:
         generation_info = json.loads(generation_info)
         if img_index < 0 or img_index >= len(generation_info["infotexts"]):
-            return html_info, gr.update(), html_info
-        return plaintext_to_html(generation_info["infotexts"][img_index]), gr.update(), generation_info["infotexts"][img_index]
+            return html_info, gr.update()
+        return plaintext_to_html(generation_info["infotexts"][img_index]), gr.update()
     except Exception:
         pass
     # if the json parse or anything else fails, just return the old html_info
-    return html_info, gr.update(), html_info
+    return html_info, gr.update()
 
 
 def plaintext_to_html(text, classname=None):
@@ -219,12 +219,18 @@ def create_output_panel(tabname, outdir, toprow=None):
                     res.generation_info = gr.Textbox(visible=False, elem_id=f'generation_info_{tabname}')
                     res.infotext_plaintext = gr.Textbox(visible=False, elem_id=f'infotext_plaintext_{tabname}')
                     if tabname == 'txt2img' or tabname == 'img2img':
+                        # set a change listener on gen info to populate infotext_plaintext
+                        res.generation_info.change(
+                            fn=lambda x: json.loads(x).get("infotexts", [""])[0],
+                            inputs=[res.generation_info],
+                            outputs=[res.infotext_plaintext]
+                        )
                         generation_info_button = gr.Button(visible=False, elem_id=f"{tabname}_generation_info_button")
                         generation_info_button.click(
                             fn=update_generation_info,
                             _js="function(x, y, z){ return [x, y, selected_gallery_index()] }",
                             inputs=[res.generation_info, res.infotext, res.infotext],
-                            outputs=[res.infotext, res.infotext, res.infotext_plaintext],
+                            outputs=[res.infotext, res.infotext],
                             show_progress=False,
                         )
 


### PR DESCRIPTION
Correction to #2349, fields to paste needs to be filtered for Seed wrt `send_seed` config option.  Added logic for the `send_size` option too, but it seems less likely that someone wouldn't want that to be True.

Might be worth a discussion if the `send_seed` option should be False by default, but idk what the impact of changing the config.json and associated `shared_option` code would be.  Thoughts very welcome.

#2359 