### PR TITLE
Fix CORS middleware not working with HTTPS origin

### DIFF
--- a/modules/initialize_util.py
+++ b/modules/initialize_util.py
@@ -214,5 +214,7 @@ def configure_cors_middleware(app):
     if cmd_opts.cors_allow_origins_regex:
         cors_options["allow_origin_regex"] = cmd_opts.cors_allow_origins_regex
 
-    app.user_middleware.insert(0, starlette.middleware.Middleware(CORSMiddleware, **cors_options))
-
+    # Clear existing middleware stack
+    app.middleware_stack = None
+    app.add_middleware(CORSMiddleware, **cors_options)
+    app.build_middleware_stack()


### PR DESCRIPTION
Fixes #2373 

After making the corrections, I confirmed the following:

- I started Forge without CORS settings, connected to Forge from both the https site and the http site, and confirmed that a CORS error occurred.

- I started Forge with CORS settings, and confirmed that I could connect to Forge from both the https site and the http site. I called the Text2Image API and confirmed that an image was generated.

- I also opened the Forge web screen with and without CORS settings, and confirmed that an image was generated by Text2Image.