### PR TITLE
Setting to hide toprow on specified tabs

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -339,6 +339,7 @@ options_templates.update(options_section(('ui', "User interface", "ui"), {
     "quick_setting_list": OptionInfo([], "Quicksettings list", ui_components.DropdownMulti, lambda: {"choices": list(shared.opts.data_labels.keys())}).js("info", "settingsHintsShowQuicksettings").info("setting entries that appear at the top of page rather than in settings tab").needs_reload_ui(),
     "ui_tab_order": OptionInfo([], "UI tab order", ui_components.DropdownMulti, lambda: {"choices": list(shared.tab_names)}).needs_reload_ui(),
     "hidden_tabs": OptionInfo([], "Hidden UI tabs", ui_components.DropdownMulti, lambda: {"choices": list(shared.tab_names)}).needs_reload_ui(),
+    "tabs_without_quick_settings_bar": OptionInfo(["Spaces"], "UI tabs without QuickSettings (top row) bar", ui_components.DropdownMulti, lambda: {"choices": list(shared.tab_names)}).needs_reload_ui(),
     "ui_reorder_list": OptionInfo([], "UI item order for txt2img/img2img tabs", ui_components.DropdownMulti, lambda: {"choices": list(shared_items.ui_reorder_categories())}).info("selected items appear first").needs_reload_ui(),
     "gradio_theme": OptionInfo("Default", "Gradio theme", ui_components.DropdownEditable, lambda: {"choices": ["Default"] + shared_gradio_themes.gradio_hf_hub_themes}).info("you can also manually enter any of themes from the <a href='https://huggingface.co/spaces/gradio/theme-gallery'>gallery</a>.").needs_reload_ui(),
     "gradio_themes_cache": OptionInfo(True, "Cache gradio themes locally").info("disable to update the selected Gradio theme"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -969,8 +969,6 @@ def create_ui():
     extensions_interface = ui_extensions.create_ui()
     interfaces += [(extensions_interface, "Extensions", "extensions")]
 
-    interface_names_without_quick_setting_bars = ["Spaces"]
-
     shared.tab_names = []
     for _interface, label, _ifid in interfaces:
         shared.tab_names.append(label)
@@ -998,7 +996,8 @@ def create_ui():
             loadsave.setup_ui()
 
         def tab_changed(evt: gr.SelectData):
-            return gr.update(visible=evt.value not in interface_names_without_quick_setting_bars)
+            no_quick_setting = getattr(shared.opts, "tabs_without_quick_settings_bar", [])
+            return gr.update(visible=evt.value not in no_quick_setting)
 
         tabs.select(tab_changed, outputs=[quicksettings_row], show_progress=False, queue=False)
 


### PR DESCRIPTION
Current: hard-coded to hide top row on *Spaces* tab only.
Change: option in *Settings > User interface*, allows any tab to have top row not visible.