### PR TITLE
avoid forcing API to send hr_additional_modules

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1402,7 +1402,7 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
             fp_additional_modules = getattr(shared.opts, 'forge_additional_modules')
 
             reload = False
-            if 'Use same choices' not in self.hr_additional_modules:
+            if hasattr(self, 'hr_additional_modules') and 'Use same choices' not in self.hr_additional_modules:
                 modules_changed = main_entry.modules_change(self.hr_additional_modules, save=False, refresh=False)
                 if modules_changed:
                     reload = True


### PR DESCRIPTION
by checking if the attribute exists
(Can't do the same test as for checkpoint `if self.hr_additional_modules`, because empty list has meaning.)