### PR TITLE
Fix LivePreview not working with fp8 UNet

### DIFF
--- a/modules/devices.py
+++ b/modules/devices.py
@@ -54,7 +54,7 @@ device_interrogate: torch.device = memory_management.text_encoder_device()  # fo
 device_gfpgan: torch.device = memory_management.get_torch_device()  # will be managed by memory management system
 device_esrgan: torch.device = memory_management.get_torch_device()  # will be managed by memory management system
 device_codeformer: torch.device = memory_management.get_torch_device()  # will be managed by memory management system
-dtype: torch.dtype = torch.float32 if memory_management.unet_dtype() == torch.float32 else torch.float16
+dtype: torch.dtype = torch.float32 if memory_management.unet_dtype() is torch.float32 else torch.float16
 dtype_vae: torch.dtype = memory_management.vae_dtype()
 dtype_unet: torch.dtype = memory_management.unet_dtype()
 dtype_inference: torch.dtype = memory_management.unet_dtype()

--- a/modules/devices.py
+++ b/modules/devices.py
@@ -54,7 +54,7 @@ device_interrogate: torch.device = memory_management.text_encoder_device()  # fo
 device_gfpgan: torch.device = memory_management.get_torch_device()  # will be managed by memory management system
 device_esrgan: torch.device = memory_management.get_torch_device()  # will be managed by memory management system
 device_codeformer: torch.device = memory_management.get_torch_device()  # will be managed by memory management system
-dtype: torch.dtype = memory_management.unet_dtype()
+dtype: torch.dtype = torch.float32 if memory_management.unet_dtype() == torch.float32 else torch.float16
 dtype_vae: torch.dtype = memory_management.vae_dtype()
 dtype_unet: torch.dtype = memory_management.unet_dtype()
 dtype_inference: torch.dtype = memory_management.unet_dtype()


### PR DESCRIPTION
### Simple Description

Many components in Forge, incluing `sd_vae_taesd`, uses `devices.dtype` as the type, and `devices.dtype` is simply set to `memory_management.unet_dtype()`, which would be `fp16` by default if supported *(`fp32` otherwise for older systems)*.

The issue occurs when the user sets the `unet_dtype` to `fp8` instead, either by using the `--unet-in-fp8-e4m3fn` arg, or by setting the `FP8 weight` option supposedly *(which doesn't actually work in Forge)*.

If the `Live preview method` is set to `TAESD` and `dtype` is set to `float8_e4m3fn`, the live preview breaks.

### Summary of Changes

Keep the `dtype` variable at `torch.float32` if the system does not support half precision; otherwise keep it at `torch.float16`

### Related Issue
[#177](https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/177), still persists in the post-Gradio4 Forge
