### PR TITLE
just to make it easier for new linux users to find the dark mode option

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1083,3 +1083,7 @@ def setup_ui_api(app):
 
     import fastapi.staticfiles
     app.mount("/webui-assets", fastapi.staticfiles.StaticFiles(directory=launch_utils.repo_dir('stable-diffusion-webui-assets')), name="webui-assets")
+
+# added the following line as inpainting does not create canvas
+def create_sampler_and_steps_selection(choices, tabname):
+    return scripts.scripts_txt2img.script('Sampler').steps, scripts.scripts_txt2img.script('Sampler').sampler_name

--- a/webui-user.sh
+++ b/webui-user.sh
@@ -10,6 +10,7 @@
 #clone_dir="stable-diffusion-webui"
 
 # Commandline arguments for webui.py, for example: export COMMANDLINE_ARGS="--medvram --opt-split-attention"
+# export COMMANDLINE_ARGS="--theme dark --xformers-flash-attention --update-check --update-all-extensions" #for example this line allows you to run "./webui.sh" in bash and forge will start in dark mode.
 #export COMMANDLINE_ARGS=""
 
 # python3 executable

--- a/webui-user.sh
+++ b/webui-user.sh
@@ -10,7 +10,7 @@
 #clone_dir="stable-diffusion-webui"
 
 # Commandline arguments for webui.py, for example: export COMMANDLINE_ARGS="--medvram --opt-split-attention"
-# export COMMANDLINE_ARGS="--theme dark --xformers-flash-attention --update-check --update-all-extensions" #for example this line allows you to run "./webui.sh" in bash and forge will start in dark mode.
+#export COMMANDLINE_ARGS="--theme dark --xformers-flash-attention --update-check --update-all-extensions" #for example this line allows you to run "./webui.sh" in bash and forge will start in dark mode.
 #export COMMANDLINE_ARGS=""
 
 # python3 executable


### PR DESCRIPTION
took me an evening to figure out how "./webui.sh" launches the app in a smarter way instead of "python launch.py" 

also to make dark mode easier to figure out. the first example did not made sense to me because i was not able to see the relation between the webui-user.sh and webui.sh

now that i realised it... i hope this minor change can help other future new users to better relate the two files.

i.e. update webui-user.sh to include arguments. then launch using ./webui.sh