### PR TITLE
Add force refresh to LoRA Loader refresh function

### DIFF
--- a/backend/patcher/lora.py
+++ b/backend/patcher/lora.py
@@ -299,10 +299,10 @@ class LoraLoader:
         self.loaded_hash = str([])
 
     @torch.inference_mode()
-    def refresh(self, lora_patches, offload_device=torch.device('cpu')):
+    def refresh(self, lora_patches, offload_device=torch.device('cpu'), force_refresh = False):
         hashes = str(list(lora_patches.keys()))
 
-        if hashes == self.loaded_hash:
+        if hashes == self.loaded_hash and not force_refresh:
             return
 
         # Merge Patches


### PR DESCRIPTION
This addresses the problem of how hard it is to reflect changes LoRA weights in the model. 
When trying to modify the LoRA weights after they’ve been loaded, I want to use refresh, but it won’t update if the number of LoRAs hasn’t changed. 
To deal with this, LoRA Block Weight tricks the refresh function by renaming the LoRA, but this isn’t ideal. 
So, I’m making changes to force updates even when the type or number of LoRAs hasn’t changed.