### PR TITLE
bump versions of bitsandbytes and accelerate

### DIFF
--- a/modules_forge/bnb_installer.py
+++ b/modules_forge/bnb_installer.py
@@ -2,7 +2,7 @@ import pkg_resources
 
 from modules.launch_utils import run_pip
 
-target_bitsandbytes_version = '0.43.3'
+target_bitsandbytes_version = '0.45.2'
 
 
 def try_install_bnb():

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,7 +1,7 @@
 setuptools==69.5.1  # temp fix for compatibility with some old packages
 GitPython==3.1.32
 Pillow==9.5.0
-accelerate==0.21.0
+accelerate==0.31.0
 blendmodes==2022
 clean-fid==0.1.35
 diskcache==5.6.3


### PR DESCRIPTION
`bitsandbytes` for CUDA 12.6 #2610 
`accelerate` to match version expected by diffusers 0.31.0, needed for some Spaces