### PR TITLE
update PhotoMaker2 Space revision

### DIFF
--- a/extensions-builtin/forge_space_photo_maker_v2/space_meta.json
+++ b/extensions-builtin/forge_space_photo_maker_v2/space_meta.json
@@ -2,5 +2,5 @@
   "tag": "Face Swap, Human Identification, and Style Transfer",
   "title": "PhotoMaker V2: Improved ID Fidelity and Better Controllability",
   "repo_id": "TencentARC/PhotoMaker-V2",
-  "revision": "abbf3252f4188b0373bb5384db31f429be40176c"
+  "revision": "745c135ad240f80e168e21db53e7acf9605edcb5"
 }


### PR DESCRIPTION
newer version no longer uses defunct `resume_download` parameter, which started to cause an error after a `diffusers` update