### PR TITLE
fix zero'd cond_t5 device (SD3)

### DIFF
--- a/backend/diffusion_engine/sd35.py
+++ b/backend/diffusion_engine/sd35.py
@@ -107,7 +107,7 @@ class StableDiffusion3(ForgeDiffusionEngine):
         if opts.sd3_enable_t5:
             cond_t5 = self.text_processing_engine_t5(prompt)
         else:
-            cond_t5 = torch.zeros([len(prompt), 256, 4096])
+            cond_t5 = torch.zeros([len(prompt), 256, 4096]).to(cond_l.device)
 
         is_negative_prompt = getattr(prompt, 'is_negative_prompt', False)
 


### PR DESCRIPTION
zeros created on CPU - the wrong device if user has enough VRAM for Forge to run text encoders on GPU.
just move it to the cond_l device