### PR TITLE
Update bitsandbytes version for cuda128 support

### DIFF
--- a/modules_forge/bnb_installer.py
+++ b/modules_forge/bnb_installer.py
@@ -2,7 +2,7 @@ import pkg_resources
 
 from modules.launch_utils import run_pip
 
-target_bitsandbytes_version = '0.45.2'
+target_bitsandbytes_version = '0.45.3'
 
 
 def try_install_bnb():


### PR DESCRIPTION
This fixes the error:
```
WARNING:bitsandbytes.cextension:Could not find the bitsandbytes CUDA binary at WindowsPath('G:/Data/Packages/stable-diffusion-webui-forge/venv/lib/site-packages/bitsandbytes/libbitsandbytes_cuda128.dll')
WARNING:bitsandbytes.cextension:The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers, 8-bit multiplication, and GPU quantization are unavailable.
```

when using cuda 12.8 builds of torch (for example, on RTX 5000-series GPUs). It does not fix the fact that cu128 versions of torch are required for these GPUs still, just the bitsandbytes portion.

[Bitsandbytes 0.45.3](https://pypi.org/project/bitsandbytes/0.45.3/) was released a few days ago and now comes with cuda 12.8 builds.

Can confirm that it fixes it for our users with RTX 5000-series/Blackwell GPUs, and that it also does not break existing functionality for my RTX 4000-series GPU.