### PR TITLE
Bump open-clip-torch to 2.24.0 and protobuf to 4.25.6 (fixes: #1092)

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -16,9 +16,9 @@ kornia==0.6.7
 lark==1.1.2
 numpy==1.26.2
 omegaconf==2.2.3
-open-clip-torch==2.20.0
+open-clip-torch==2.24.0
 piexif==1.1.3
-protobuf==3.20.0
+protobuf==4.25.5
 psutil==5.9.5
 pytorch_lightning==1.9.4
 resize-right==0.0.2


### PR DESCRIPTION
Fixes: #1092 . Fixes mediapipe errors as open-clip-torch > 2.23.0 removed protofbuf version requirement. Working locally.