### PR TITLE
Add separate cuda stream for live preview VAE

### DIFF
--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -70,9 +70,12 @@ def samples_to_images_tensor(sample, approximation=None, model=None):
 def single_sample_to_image(sample, approximation=None):
     x_sample = samples_to_images_tensor(sample.unsqueeze(0), approximation)[0] * 0.5 + 0.5
 
-    x_sample = torch.clamp(x_sample, min=0.0, max=1.0)
-    x_sample = 255. * np.moveaxis(x_sample.cpu().numpy(), 0, 2)
-    x_sample = x_sample.astype(np.uint8)
+    x_sample = x_sample.cpu()
+    x_sample.clamp_(0.0, 1.0)
+    x_sample.mul_(255.)
+    x_sample.round_()
+    x_sample = x_sample.to(torch.uint8)
+    x_sample = np.moveaxis(x_sample.numpy(), 0, 2)
 
     return Image.fromarray(x_sample)
 

--- a/modules/shared_state.py
+++ b/modules/shared_state.py
@@ -4,8 +4,10 @@ import threading
 import time
 import traceback
 import torch
+from contextlib import nullcontext
 
 from modules import errors, shared, devices
+from backend.args import args
 from typing import Optional
 
 log = logging.getLogger(__name__)
@@ -34,6 +36,10 @@ class State:
 
     def __init__(self):
         self.server_start = time.time()
+        if args.cuda_stream:
+            self.vae_stream = torch.cuda.Stream()
+        else:
+            self.vae_stream = None
 
     @property
     def need_restart(self) -> bool:
@@ -153,12 +159,18 @@ class State:
         import modules.sd_samplers
 
         try:
-            if shared.opts.show_progress_grid:
-                self.assign_current_image(modules.sd_samplers.samples_to_image_grid(self.current_latent))
+            if self.vae_stream is not None:
+                # not waiting on default stream will result in corrupt results
+                # will not block main stream under any circumstances
+                self.vae_stream.wait_stream(torch.cuda.default_stream())
+                vae_context = torch.cuda.stream(self.vae_stream)
             else:
-                self.assign_current_image(modules.sd_samplers.sample_to_image(self.current_latent))
-
-            self.current_image_sampling_step = self.sampling_step
+                vae_context = nullcontext()
+            with vae_context:
+                if shared.opts.show_progress_grid:
+                    self.assign_current_image(modules.sd_samplers.samples_to_image_grid(self.current_latent))
+                else:
+                    self.assign_current_image(modules.sd_samplers.sample_to_image(self.current_latent))
 
         except Exception as e:
             # traceback.print_exc()


### PR DESCRIPTION
This adds a separate CUDA stream (if cuda streams are enabled in args) for the live preview VAE so that the live preview processing can happen in parallel with main processing, and especially so that transferring the decoded image to the CPU does not block the main processing stream (should be beneficial since it is by far the largest blocking call, but would be much more beneficial if all blocking calls were removed from the main processing loop).

Internally, this should be handled very safely. If cudastreams are disabled, nothing happens differently than before. If cuda streams are enabled, we wait for the main stream to catch up before starting VAE processing so we don't grab some intermediate garbage tensor (this only blocks the live preview thread and will never block the main thread). Since the operation to move images to the CPU is already blocking and forces a sync (albeit on the VAE stream and not the main one) we don't need to ensure this stream is synced at the end.

While doing this I also did a couple of changes to the function for converting decoded images to PIL images. Converting float to uint8 should always use rounding because the default behavior when casting float to int is to truncate, but in image processing rounding to nearest int is the standard, and I set it up to do that now. I also changed it to use inplace operations where appropriate and for the clamp/etc operations to be done on the CPU.

This doesn't support XPU streams but could presumably be easily modified for it, I would want someone else who can actually test that to implement that though.

This is how the compute overlap looks in Nsight Systems. Default Stream 7 is the main stream, Stream 21 is the VAE stream. Live preview is set to every step:
![image](https://github.com/user-attachments/assets/13e7b8f2-b57a-4c34-91cc-8e0937726f38)

Zoomed in view on one of the decoding sections:

![image](https://github.com/user-attachments/assets/449749fd-97fa-4a16-8fb3-91e058c7925e)

CUDA stream synchronize here is where the VAE thread is waiting on the main stream to finish a step before starting to decode. As you can see, the main stream continues unimpeded.

If you look very closely at the Kernel utilization at the very top, you will notice that while doing VAE processing utilization is absolutely 100%, whereas there are some small dips during other sections. This is part of the performance benefit of using the live preview VAE this way, it can use some SMs that aren't being used by the current kernel on the main processing stream.

Also notable, on this I do have all of the blocking functions removed from the code so you can see the CUDA Overhead section showing a bunch of "Command Buffer Full" events. This won't happen on this yet but it is a step towards being able to have that happen.