### PR TITLE
Fix Runtime Error: "The model is mixed with different device type" on Intel XPU

### DIFF
--- a/backend/memory_management.py
+++ b/backend/memory_management.py
@@ -518,7 +518,8 @@ class LoadedModel:
         self.model.refresh_loras()
 
         if is_intel_xpu() and not args.disable_ipex_hijack:
-            self.real_model = torch.xpu.optimize(self.real_model.eval(), inplace=True, auto_kernel_selection=True, graph_mode=True)
+            #self.real_model = torch.xpu.optimize(self.real_model.eval(), inplace=True, auto_kernel_selection=True, graph_mode=True)
+            self.real_model = self.real_model.eval()
 
         return self.real_model
 


### PR DESCRIPTION
When using newest IPEX (v2.7.10+xpu), torch.xpu.optimize() function will throw Runtime Error if the model is not wholly on CPU or GPU, therefore I remove it for offloading to work properly