### PR TITLE
Prevent accidental page navigation

### DIFF
--- a/script.js
+++ b/script.js
@@ -135,15 +135,15 @@ document.addEventListener("DOMContentLoaded", function() {
     mutationObserver.observe(gradioApp(), {childList: true, subtree: true});
 });
 
-/*
+/**
  * Add a confirmation dialog when leaving the page
  * Useful to avoid data loss
-*/
+ */
 window.addEventListener("beforeunload", function (event) {
-  // Cancel the event
-  event.preventDefault();
-  // Chrome requires returnValue to be set
-  event.returnValue = "";
+    // Cancel the event
+    event.preventDefault();
+    // Chrome requires returnValue to be set
+    event.returnValue = "";
 });
 
 /**

--- a/script.js
+++ b/script.js
@@ -135,6 +135,17 @@ document.addEventListener("DOMContentLoaded", function() {
     mutationObserver.observe(gradioApp(), {childList: true, subtree: true});
 });
 
+/*
+ * Add a confirmation dialog when leaving the page
+ * Useful to avoid data loss
+*/
+window.addEventListener("beforeunload", function (event) {
+  // Cancel the event
+  event.preventDefault();
+  // Chrome requires returnValue to be set
+  event.returnValue = "";
+});
+
 /**
  * Add keyboard shortcuts:
  * Ctrl+Enter to start/restart a generation


### PR DESCRIPTION
Intercept page navigation events (back/forward, reload, close) and prompt the user with a modal dialog:
![image](https://github.com/user-attachments/assets/05a82528-2bc3-46eb-8970-6274aa12ab0f)
This gives the user a chance to confirm or abort, preventing accidents.

Lightly tested, but it's the same trick oobabooga text-gen uses.

Closes #529