### PR TITLE
Bug fixes on softinpainting.

### DIFF
--- a/extensions-builtin/soft-inpainting/scripts/soft_inpainting.py
+++ b/extensions-builtin/soft-inpainting/scripts/soft_inpainting.py
@@ -389,10 +389,11 @@ def weighted_histogram_filter(img, kernel, kernel_center, percentile_min=0.0, pe
         return np.sum(values * overlap) / np.sum(overlap) if np.sum(overlap) > 0 else 0
 
     # Split pixel_coords into equal chunks based on n_jobs
-    n_jobs = -1
+    n_jobs = 1
     if cpu_count() > 6:
         n_jobs = 6 # More than 6 isn't worth unless it's more than 3000x3000px
-
+    else:
+        n_jobs = cpu_count() # Assign all cores if there are less than 7
     chunk_size = len(pixel_coords) // n_jobs
     pixel_chunks = [pixel_coords[i:i + chunk_size] for i in range(0, len(pixel_coords), chunk_size)]
 

--- a/extensions-builtin/soft-inpainting/scripts/soft_inpainting.py
+++ b/extensions-builtin/soft-inpainting/scripts/soft_inpainting.py
@@ -530,7 +530,7 @@ el_ids = SoftInpaintingSettings(
 
 class Script(scripts.Script):
     def __init__(self):
-        self.section = "inpaint"
+        # self.section = "inpaint"
         self.masks_for_overlay = None
         self.overlay_images = None
 

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -41,3 +41,4 @@ tqdm==4.66.1
 peft==0.13.2
 pydantic==2.8.2
 huggingface-hub==0.26.2
+joblib==1.5.1


### PR DESCRIPTION
Added dependency joblib 1.5.1 (python 3.9-3.13) for latest changes on soft inpainting. And rolled back section as users are used to how it was before.
Also fix for CPUs with 6 cores or fewer.

Tested on a fresh installation windows 11 (python 3.11.9) and debian 12 (python 3.11.12).