### PR TITLE
Fix: Issue #2709　Change default value of stealth_pnginfo_option to "None" to prevent unintended alpha channel watermarking

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -358,7 +358,7 @@ Infotext is what this software calls the text that contains generation parameter
 It is displayed in UI below the image. To use infotext, paste it into the prompt and click the ↙️ paste button.
 """),
     "enable_pnginfo": OptionInfo(True, "Write infotext to metadata of the generated image"),
-    "stealth_pnginfo_option": OptionInfo("Alpha", "Stealth infotext mode", gr.Radio, {"choices": ["Alpha", "RGB", "None"]}).info("Ignored if infotext is disabled"),
+    "stealth_pnginfo_option": OptionInfo("None", "Stealth infotext mode", gr.Radio, {"choices": ["Alpha", "RGB", "None"]}).info("Ignored if infotext is disabled"),
     "save_txt": OptionInfo(False, "Create a text file with infotext next to every generated image"),
 
     "add_model_name_to_info": OptionInfo(True, "Add model name to infotext"),


### PR DESCRIPTION
This pull request addresses #2709 regarding the unintentional embedding of stealth metadata (a hidden watermark) into the alpha channel of generated images.

Reason:
- The default setting of "Alpha" caused stealth metadata to be embedded in the alpha channel even when users were unaware of it.
- This has led to real-world consequences, including targeted harassment of artists who assumed they had removed all metadata.
- Setting the default to "None" ensures that users must explicitly opt in if they want stealth metadata.
- This aligns with privacy expectations and avoids unintentional leaks of prompt or generation details.

Impact:
- This change does not remove the feature, but makes it opt-in instead of opt-out.
- No effect for users who have already configured this setting manually.