### PR TITLE
Pad SDXL Tokens to Prevent Tensor Mismatch 

### DIFF
--- a/backend/diffusion_engine/sdxl.py
+++ b/backend/diffusion_engine/sdxl.py
@@ -89,6 +89,19 @@ class StableDiffusionXL(ForgeDiffusionEngine):
         cond_l = self.text_processing_engine_l(prompt)
         cond_g, clip_pooled = self.text_processing_engine_g(prompt)
 
+        if cond_l.shape[1] < cond_g.shape[1]:
+            pad = cond_g.shape[1] - cond_l.shape[1]
+            cond_l = torch.cat([
+                cond_l,
+                cond_l.new_zeros(cond_l.size(0), pad, cond_l.size(2))
+            ], dim=1)
+        elif cond_g.shape[1] < cond_l.shape[1]:
+            pad = cond_l.shape[1] - cond_g.shape[1]
+            cond_g = torch.cat([
+                cond_g,
+                cond_g.new_zeros(cond_g.size(0), pad, cond_g.size(2))
+            ], dim=1)
+        
         width = getattr(prompt, 'width', 1024) or 1024
         height = getattr(prompt, 'height', 1024) or 1024
         is_negative_prompt = getattr(prompt, 'is_negative_prompt', False)


### PR DESCRIPTION
There is a rare instance when prompt length is too long in SDXL causing a tensor mismatch, as mentioned in #2540. Added padding logic in “get_learned_conditioning” to ensure equal token lengths before concatenating the local and global conditionings in SDXL, preventing shape mismatches during inference. When the local and global conditioning tensors have different lengths, the shorter tensor is padded with zeros before concatenation.