### PR TITLE
fix that --all-in-fp32 option is ignored on mps devices

### DIFF
--- a/backend/memory_management.py
+++ b/backend/memory_management.py
@@ -1077,12 +1077,12 @@ def should_use_fp16(device=None, model_params=0, prioritize_performance=True, ma
     if FORCE_FP16:
         return True
 
+    if FORCE_FP32:
+        return False
+
     if device is not None:
         if is_device_mps(device):
             return True
-
-    if FORCE_FP32:
-        return False
 
     if directml_enabled:
         return False
@@ -1135,12 +1135,12 @@ def should_use_bf16(device=None, model_params=0, prioritize_performance=True, ma
         if is_device_cpu(device):  # TODO ? bf16 works on CPU but is extremely slow
             return False
 
+    if FORCE_FP32:
+        return False
+
     if device is not None:
         if is_device_mps(device):
             return True
-
-    if FORCE_FP32:
-        return False
 
     if directml_enabled:
         return False


### PR DESCRIPTION
`--all-in-fp32` flag is being ignored currently due to the mps check comes before it. Was there a reason for it or is it unintended bug?

For context, I get cast errors during VAE decode if fp16 is used during inference when running SDXL models in bf16. Updating the `computation_dtype` to fp32 fixes it for me. I had to force it by updating code because the option is ignored.