### PR TITLE
Add --use-directml flag and fix crash when no NVIDIA GPU is present

### DIFF
--- a/backend/args.py
+++ b/backend/args.py
@@ -39,6 +39,7 @@ upcast.add_argument("--disable-attention-upcast", action="store_true")
 parser.add_argument("--disable-xformers", action="store_true")
 
 parser.add_argument("--directml", type=int, nargs="?", metavar="DIRECTML_DEVICE", const=-1)
+parser.add_argument("--use-directml", action="store_true", dest="use_directml")
 parser.add_argument("--disable-ipex-hijack", action="store_true")
 
 vram_group = parser.add_mutually_exclusive_group()

--- a/backend/memory_management.py
+++ b/backend/memory_management.py
@@ -44,7 +44,9 @@ if args.pytorch_deterministic:
     torch.use_deterministic_algorithms(True, warn_only=True)
 
 directml_enabled = False
-if args.directml is not None:
+if args.directml is not None or getattr(args, 'use_directml', False):
+    if args.directml is None:
+        args.directml = -1
     import torch_directml
 
     directml_enabled = True
@@ -96,8 +98,10 @@ def get_torch_device():
     else:
         if is_intel_xpu():
             return torch.device("xpu", torch.xpu.current_device())
-        else:
+        elif torch.cuda.is_available():
             return torch.device(torch.cuda.current_device())
+        else:
+            return torch.device("cpu")
 
 
 def get_total_memory(dev=None, torch_total_too=False):


### PR DESCRIPTION
## Summary

- **Root cause:** `--use-directml` was not a recognized argument — `parse_known_args()` silently ignored it, leaving `directml_enabled = False` and causing the code to fall through to `torch.cuda.current_device()`, which crashes with *"Found no NVIDIA driver on your system"* on non-NVIDIA systems.
- Added `--use-directml` as an alias for `--directml` in `backend/args.py` (defaults to device index `-1`).
- Added a `torch.cuda.is_available()` guard in `get_torch_device()` before calling `torch.cuda.current_device()`, falling back to CPU to prevent crashes on non-NVIDIA hardware.

## Test plan

- [ ] Launch with `--use-directml` — verify `"Using directml with device: ..."` appears in log and app starts successfully
- [ ] Launch without NVIDIA GPU and without `--use-directml` / `--directml` — verify app falls back to CPU instead of crashing
- [ ] Launch with `--directml` (original flag) — verify existing behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)