### PR TITLE
Pin setuptools and use no-build-isolation

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -360,6 +360,26 @@ def requirements_met(requirements_file):
     return True
 
 
+def ensure_setuptools():
+    """Ensure the venv has a setuptools version that still ships pkg_resources.
+
+    setuptools >= 82 removed pkg_resources, which breaks legacy packages
+    (e.g. CLIP) that import it in their setup.py.  Pin to the version
+    declared in requirements_versions.txt so that --no-build-isolation
+    installs work correctly.
+    """
+    target = "69.5.1"  # must match requirements_versions.txt
+    try:
+        current = importlib.metadata.version("setuptools")
+        from packaging.version import parse
+        if parse(current) >= parse("82"):
+            run(f'"{python}" -m pip install setuptools=={target}',
+                desc=f"Pinning setuptools to {target} (pkg_resources fix)",
+                errdesc="Couldn't pin setuptools")
+    except Exception:
+        pass
+
+
 def prepare_environment():
     torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu121")
     torch_command = os.environ.get('TORCH_COMMAND', f"pip install torch==2.3.1 torchvision==0.18.1 --extra-index-url {torch_index_url}")
@@ -439,12 +459,19 @@ def prepare_environment():
         )
     startup_timer.record("torch GPU test")
 
+    # Ensure setuptools has pkg_resources before building packages from source
+    ensure_setuptools()
+    startup_timer.record("ensure setuptools")
+
     if not is_installed("clip"):
-        run_pip(f"install {clip_package}", "clip")
+        # Use --no-build-isolation so the build uses the venv's pinned
+        # setuptools (which still has pkg_resources) instead of pip pulling
+        # the latest setuptools (v82+) which removed it.
+        run_pip(f"install --no-build-isolation {clip_package}", "clip")
         startup_timer.record("install clip")
 
     if not is_installed("open_clip"):
-        run_pip(f"install {openclip_package}", "open_clip")
+        run_pip(f"install --no-build-isolation {openclip_package}", "open_clip")
         startup_timer.record("install open_clip")
 
     if (not is_installed("xformers") or args.reinstall_xformers) and args.xformers:

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -369,17 +369,34 @@ def ensure_setuptools():
     installs work correctly.
     """
     target = "69.5.1"  # must match requirements_versions.txt
+
+    # Try to determine the currently installed setuptools version.
     try:
         current = importlib.metadata.version("setuptools")
-        from packaging.version import parse
-        if parse(current) >= parse("82"):
-            run(f'"{python}" -m pip install setuptools=={target}',
-                desc=f"Pinning setuptools to {target} (pkg_resources fix)",
-                errdesc="Couldn't pin setuptools")
-    except Exception:
-        pass
+    except importlib.metadata.PackageNotFoundError:
+        # setuptools is not installed; install the pinned version so that
+        # legacy packages depending on pkg_resources can build correctly.
+        run(
+            f'"{python}" -m pip install setuptools=={target}',
+            desc=f"Installing setuptools=={target} (pkg_resources fix)",
+            errdesc="Couldn't install setuptools",
+        )
+        return
+    except Exception as e:
+        # Unexpected error while checking setuptools; log and return without
+        # silently hiding the problem.
+        logging.warning("Failed to determine setuptools version: %s", e)
+        return
 
+    from packaging.version import parse
 
+    # If setuptools is too new (pkg_resources removed), pin it to the target.
+    if parse(current) >= parse("82"):
+        run(
+            f'"{python}" -m pip install setuptools=={target}',
+            desc=f"Pinning setuptools to {target} (pkg_resources fix)",
+            errdesc="Couldn't pin setuptools",
+        )
 def prepare_environment():
     torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu121")
     torch_command = os.environ.get('TORCH_COMMAND', f"pip install torch==2.3.1 torchvision==0.18.1 --extra-index-url {torch_index_url}")


### PR DESCRIPTION
Add ensure_setuptools() to pin setuptools to 69.5.1 (matches requirements_versions.txt) so the venv retains pkg_resources removed in setuptools>=82. Call this before building/installing packages and record a startup timer. Also install clip and open_clip with --no-build-isolation so their builds use the pinned setuptools, preventing setup-time imports of pkg_resources from failing.