### PR TITLE
Add Python 3.12 support and refresh compatible dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Note that running `update.bat` is important, otherwise you may be using a previo
 
 If you are proficient in Git and you want to install Forge as another branch of SD-WebUI, please see [here](https://github.com/continue-revolution/sd-webui-animatediff/blob/forge/master/docs/how-to-use.md#you-have-a1111-and-you-know-git). In this way, you can reuse all SD checkpoints and all extensions you installed previously in your OG SD-WebUI, but you should know what you are doing.
 
-If you know what you are doing, you can also install Forge using same method as SD-WebUI. (Install Git, Python, Git Clone the forge repo `https://github.com/lllyasviel/stable-diffusion-webui-forge.git` and then run webui-user.bat).
+If you know what you are doing, you can also install Forge using same method as SD-WebUI. Install Git and Python 3.10, 3.11, or 3.12, clone the Forge repo `https://github.com/lllyasviel/stable-diffusion-webui-forge.git`, and then run `webui-user.bat`.
 
 ### Previous Versions
 

--- a/modules/images.py
+++ b/modules/images.py
@@ -168,9 +168,13 @@ def draw_grid_annotations(im, width, height, hor_texts, ver_texts, margin=0):
         for line in lines:
             fnt = initial_fnt
             fontsize = initial_fontsize
-            while drawing.multiline_textsize(line.text, font=fnt)[0] > line.allowed_width and fontsize > 0:
+            bbox = drawing.multiline_textbbox((0, 0), line.text, font=fnt)
+            text_width = bbox[2] - bbox[0]
+            while text_width > line.allowed_width and fontsize > 0:
                 fontsize -= 1
                 fnt = get_font(fontsize)
+                bbox = drawing.multiline_textbbox((0, 0), line.text, font=fnt)
+                text_width = bbox[2] - bbox[0]
             drawing.multiline_text((draw_x, draw_y + line.size[1] / 2), line.text, font=fnt, fill=color_active if line.is_active else color_inactive, anchor="mm", align="center")
 
             if not line.is_active:

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -35,6 +35,17 @@ default_command_live = (os.environ.get('WEBUI_LAUNCH_LIVE_OUTPUT') == "1")
 
 os.environ.setdefault('GRADIO_ANALYTICS_ENABLED', 'False')
 
+WINDOWS_SUPPORTED_PYTHON_MINORS = (10, 11, 12)
+OTHER_SUPPORTED_PYTHON_MINORS = (7, 8, 9, 10, 11, 12)
+
+
+def is_python_version_supported(version_info=None, system=None):
+    version_info = version_info or sys.version_info
+    system = system or platform.system()
+    supported_minors = WINDOWS_SUPPORTED_PYTHON_MINORS if system == "Windows" else OTHER_SUPPORTED_PYTHON_MINORS
+
+    return version_info.major == 3 and version_info.minor in supported_minors
+
 
 def check_python_version():
     is_windows = platform.system() == "Windows"
@@ -42,24 +53,19 @@ def check_python_version():
     minor = sys.version_info.minor
     micro = sys.version_info.micro
 
-    if is_windows:
-        supported_minors = [10]
-    else:
-        supported_minors = [7, 8, 9, 10, 11]
-
-    if not (major == 3 and minor in supported_minors):
+    if not is_python_version_supported():
         import modules.errors
 
         modules.errors.print_error_explanation(f"""
 INCOMPATIBLE PYTHON VERSION
 
-This program is tested with 3.10.6 Python, but you have {major}.{minor}.{micro}.
+This program is tested with Python 3.10 through 3.12, but you have {major}.{minor}.{micro}.
 If you encounter an error with "RuntimeError: Couldn't install torch." message,
 or any other error regarding unsuccessful package (library) installation,
-please downgrade (or upgrade) to the latest version of 3.10 Python
+please install the latest patch release of Python 3.10, 3.11, or 3.12
 and delete current Python and "venv" folder in WebUI's directory.
 
-You can download 3.10 Python from here: https://www.python.org/downloads/release/python-3106/
+You can download Python from here: https://www.python.org/downloads/
 
 {"Alternatively, use a binary release of WebUI: https://github.com/AUTOMATIC1111/stable-diffusion-webui/releases/tag/v1.0.0-pre" if is_windows else ""}
 
@@ -360,6 +366,41 @@ def requirements_met(requirements_file):
     return True
 
 
+def pinned_requirement_version(requirements_file, package_name):
+    if not os.path.isfile(requirements_file):
+        requirements_file = os.path.join(script_path, requirements_file)
+
+    with open(requirements_file, "r", encoding="utf8") as file:
+        for line in file:
+            match = re.match(re_requirement, line)
+            if match is None:
+                continue
+
+            name = match.group(1).strip()
+            version = (match.group(2) or "").strip()
+            if name.casefold() == package_name.casefold() and version:
+                return version
+
+    return None
+
+
+def ensure_setuptools(requirements_file):
+    if args.skip_install:
+        return
+
+    target = pinned_requirement_version(requirements_file, "setuptools")
+    if target is None:
+        raise RuntimeError(f"Couldn't determine the setuptools version from {requirements_file}")
+
+    try:
+        current = importlib.metadata.version("setuptools")
+    except importlib.metadata.PackageNotFoundError:
+        current = None
+
+    if current != target:
+        run_pip(f"install setuptools=={target}", f"setuptools=={target}")
+
+
 def prepare_environment():
     torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu121")
     torch_command = os.environ.get('TORCH_COMMAND', f"pip install torch==2.3.1 torchvision==0.18.1 --extra-index-url {torch_index_url}")
@@ -439,12 +480,17 @@ def prepare_environment():
         )
     startup_timer.record("torch GPU test")
 
+    # Python 3.12 venvs do not include setuptools by default. Install the
+    # project-pinned version before building legacy packages such as CLIP.
+    ensure_setuptools(requirements_file)
+    startup_timer.record("ensure setuptools")
+
     if not is_installed("clip"):
-        run_pip(f"install {clip_package}", "clip")
+        run_pip(f"install --no-build-isolation {clip_package}", "clip")
         startup_timer.record("install clip")
 
     if not is_installed("open_clip"):
-        run_pip(f"install {openclip_package}", "open_clip")
+        run_pip(f"install --no-build-isolation {openclip_package}", "open_clip")
         startup_timer.record("install open_clip")
 
     if (not is_installed("xformers") or args.reinstall_xformers) and args.xformers:

--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,8 +1,8 @@
 setuptools==69.5.1  # temp fix for compatibility with some old packages
 GitPython==3.1.32
-Pillow==9.5.0
+Pillow==10.4.0
 accelerate==0.31.0
-blendmodes==2022
+blendmodes==2024.1.1
 clean-fid==0.1.35
 diskcache==5.6.3
 einops==0.4.1
@@ -14,7 +14,7 @@ inflection==0.5.1
 jsonmerge==1.8.0
 kornia==0.6.7
 lark==1.1.2
-numpy==1.26.2
+numpy==1.26.4
 omegaconf==2.2.3
 open-clip-torch==2.20.0
 piexif==1.1.3
@@ -23,7 +23,7 @@ psutil==5.9.5
 pytorch_lightning==1.9.4
 resize-right==0.0.2
 safetensors==0.4.2
-scikit-image==0.21.0
+scikit-image==0.22.0
 spandrel==0.3.4
 spandrel-extra-arches==0.1.1
 tomesd==0.1.3

--- a/tests/test_python_compatibility.py
+++ b/tests/test_python_compatibility.py
@@ -1,0 +1,78 @@
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from modules import launch_utils
+
+
+def version(major, minor, micro=0):
+    return SimpleNamespace(major=major, minor=minor, micro=micro)
+
+
+class PythonCompatibilityTests(unittest.TestCase):
+    def test_windows_supports_python_310_through_312(self):
+        for minor in (10, 11, 12):
+            with self.subTest(minor=minor):
+                self.assertTrue(launch_utils.is_python_version_supported(version(3, minor), "Windows"))
+
+    def test_other_platforms_keep_existing_versions_and_add_312(self):
+        for minor in (7, 8, 9, 10, 11, 12):
+            with self.subTest(minor=minor):
+                self.assertTrue(launch_utils.is_python_version_supported(version(3, minor), "Linux"))
+
+    def test_unsupported_versions_are_rejected(self):
+        unsupported = (
+            (version(2, 12), "Windows"),
+            (version(3, 9), "Windows"),
+            (version(3, 13), "Windows"),
+            (version(3, 13), "Linux"),
+        )
+
+        for version_info, system in unsupported:
+            with self.subTest(version=version_info, system=system):
+                self.assertFalse(launch_utils.is_python_version_supported(version_info, system))
+
+    def test_current_interpreter_is_supported(self):
+        self.assertTrue(launch_utils.is_python_version_supported())
+
+
+class RequirementsBootstrapTests(unittest.TestCase):
+    @property
+    def requirements_file(self):
+        return Path(__file__).parents[1] / "requirements_versions.txt"
+
+    def test_setuptools_pin_is_read_from_requirements(self):
+        self.assertEqual(
+            launch_utils.pinned_requirement_version(self.requirements_file, "setuptools"),
+            "69.5.1",
+        )
+
+    def test_missing_requirement_returns_none(self):
+        self.assertIsNone(
+            launch_utils.pinned_requirement_version(self.requirements_file, "not-a-package"),
+        )
+
+    def test_missing_setuptools_is_bootstrapped(self):
+        with mock.patch.object(launch_utils.args, "skip_install", False), \
+                mock.patch.object(
+                    launch_utils.importlib.metadata,
+                    "version",
+                    side_effect=launch_utils.importlib.metadata.PackageNotFoundError,
+                ), \
+                mock.patch.object(launch_utils, "run_pip") as run_pip:
+            launch_utils.ensure_setuptools(self.requirements_file)
+
+        run_pip.assert_called_once_with("install setuptools==69.5.1", "setuptools==69.5.1")
+
+    def test_matching_setuptools_is_not_reinstalled(self):
+        with mock.patch.object(launch_utils.args, "skip_install", False), \
+                mock.patch.object(launch_utils.importlib.metadata, "version", return_value="69.5.1"), \
+                mock.patch.object(launch_utils, "run_pip") as run_pip:
+            launch_utils.ensure_setuptools(self.requirements_file)
+
+        run_pip.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- accept Python 3.10, 3.11, and 3.12 on Windows while retaining the existing non-Windows range and adding 3.12
- update Pillow, blendmodes, NumPy, and scikit-image to versions with Python 3.12 wheels
- bootstrap the project-pinned setuptools version for clean Python 3.12 virtual environments
- install legacy CLIP packages without build isolation so they use the compatible setuptools pin
- replace Pillow's removed `multiline_textsize` API with `multiline_textbbox`
- document the supported manual-install Python versions and add focused compatibility tests

## Why

Clean Python 3.12 virtual environments do not include setuptools by default, and the previous `scikit-image==0.21.0` pin does not provide a Windows CPython 3.12 wheel. Updating Pillow also requires replacing the removed text-measurement API used by grid annotations.

This extends the dependency work discussed in #2985 and includes the clean-environment bootstrap concern addressed by #3110.

## User impact

Manual installations can use Python 3.12 without bypassing the version check or compiling scikit-image locally. Existing Python 3.10 and 3.11 installations remain accepted.

## Validation

- `python -m unittest discover -s tests -v` — 8 tests passed on Python 3.12.13
- `python -m compileall -q modules/launch_utils.py modules/images.py tests/test_python_compatibility.py`
- `ruff check tests/test_python_compatibility.py`
- full `pip install --dry-run` of `requirements_versions.txt` on CPython 3.12 for Windows
- fresh Python 3.12 venv bootstrap from no setuptools to `setuptools==69.5.1`
- binary-wheel and API smoke tests for Pillow 10.4.0, blendmodes 2024.1.1, NumPy 1.26.4, and scikit-image 0.22.0

Full GPU inference was not run because this validation environment does not contain Forge model assets.
