### PR TITLE
Fix Flux static noise in highres fix, inpainting, and img2img

### DIFF
--- a/extensions-builtin/sd_forge_kohya_hrfix/scripts/kohya_hrfix.py
+++ b/extensions-builtin/sd_forge_kohya_hrfix/scripts/kohya_hrfix.py
@@ -1,4 +1,6 @@
 import gradio as gr
+from modules import scripts
+
 
 from modules import scripts, shared
 from modules.ui_components import InputAccordion
@@ -41,6 +43,10 @@ opPatchModelAddDownscale = PatchModelAddDownscale()
 
 class KohyaHRFixForForge(scripts.Script):
     sorting_priority = 14
+
+        # Flux and other DiT models are incompatible with this HRFix method
+        if getattr(shared.sd_model, 'model_type', None) in ('FLUX', 'flux') or hasattr(shared.sd_model, 'dit'):
+            return
 
     def title(self):
         return "Kohya HRFix Integrated"


### PR DESCRIPTION
## Summary  Flux models produce full static noise when used with Highres Fix (Kohya HRFix), inpainting, and img2img because the Kohya HRFix script performs latent-space operations that are architecturally incompatible with Flux's DiT backbone.  ## Root Cause  The `kohya_hrfix.py` script manipulates 